### PR TITLE
Serve vue build files from express

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ content/logs/*.log
 # frontend
 frontend/dist
 
+# Server
+server/public
+
 # local env files
 .env
 .env.local

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,6 +1,9 @@
+const path = require('path')
+
 const serverPort = process.env.VUE_APP_SERVER_PORT || 3000;
 
 module.exports = {
+	outputDir: path.resolve(__dirname, "../server/public"),
 	devServer: {
 		proxy: {
 			'/api': {

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ const startTime = Date.now();
 const express = require("express");
 const cors = require("cors");
 const bodyParser = require("body-parser");
+const path = require("path");
 
 const routes = require("./routes/v1");
 
@@ -36,6 +37,13 @@ database
 						// importing all routes modules
 						app.use(routes);
 
+						// Serve vue app
+						if (process.env.NODE_ENV === "production") {
+							app.use(express.static(path.resolve(__dirname, "public")));
+							app.get(/.*/, (req, res) =>
+								res.sendFile(path.resolve(__dirname, "public/index.html"))
+							);
+						}
 
 						// start express server at SERVER_PORT
 						const port = process.env.PORT || 3000;

--- a/server/app.js
+++ b/server/app.js
@@ -27,19 +27,21 @@ database
 					.then(() => {
 						logger.info("Database migration complete");
 
+						// contains key-value pairs of data submitted in the request body
+						app.use(bodyParser.json());
+
+						// enable all CORS requests
+						app.use(cors());
+
+						// importing all routes modules
+						app.use(routes);
+
+
 						// start express server at SERVER_PORT
-						app.listen(process.env.SERVER_PORT, () => {
-							// contains key-value pairs of data submitted in the request body
-							app.use(bodyParser.json());
-
-							// enable all CORS requests
-							app.use(cors());
-
-							// importing all routes modules
-							app.use(routes);
-
+						const port = process.env.PORT || 3000;
+						app.listen(port, () => {
 							logger.info(`LogChimp is running in ${process.env.NODE_ENV}...`);
-							logger.info(`Listening on port: ${process.env.SERVER_PORT}`);
+							logger.info(`Listening on port: ${port}`);
 							logger.info("Ctrl+C to shut down");
 							logger.info(`LogChimp boot ${(Date.now() - startTime) / 1000}s`);
 						});


### PR DESCRIPTION
This PR add support for running both frontend and backend under single port.

As the Vue.js build files are output to `server/public` directory, which is served by `express.static` method.