### PR TITLE
fix: post content line break on client side

### DIFF
--- a/packages/server/controllers/post/create.js
+++ b/packages/server/controllers/post/create.js
@@ -55,8 +55,6 @@ exports.create = async (req, res) => {
     .split(" ")
     .join("-")}-${slugId}`;
 
-  const contentHtml = contentMarkdown.replace(/\n/g, '<br>');
-
   try {
     const createPost = await database
       .insert({
@@ -64,7 +62,7 @@ exports.create = async (req, res) => {
         title,
         slug,
         slugId,
-        contentMarkdown: contentHtml,
+        contentMarkdown,
         userId,
         boardId,
       })

--- a/packages/theme/src/pages/posts/_slug/Index.vue
+++ b/packages/theme/src/pages/posts/_slug/Index.vue
@@ -53,7 +53,7 @@
 				</div>
 			</div>
 
-			<p v-html="post.contentMarkdown" />
+			<p v-html="postContent" />
 
 			<div v-if="showPostActivity" class="activity-section">
 				<add-comment @add-comment="addComment" :post-id="post.postId" />
@@ -158,6 +158,7 @@ const post = reactive({
 		viewerVote: false,
 	}
 });
+const postContent = ref<string>('');
 const postLoading = ref(false)
 const isPostExist = ref(false)
 
@@ -227,6 +228,10 @@ async function postBySlug() {
       postLoading.value = false;
 			Object.assign(post, response.data.post);
       isPostExist.value = true;
+
+      if (response.data.post.hasOwnProperty('contentMarkdown')) {
+        postContent.value = response.data.post.contentMarkdown.replace(/\n/g, '<br>');
+      }
 
 			getPostActivity();
 		} catch (error: any) {


### PR DESCRIPTION
There seems to be issue in https://github.com/logchimp/logchimp/pull/873.

![CleanShot 2023-10-15 at 17 33 02@2x](https://github.com/logchimp/logchimp/assets/29014463/9273c15b-3662-47cd-8c20-dc00c850b2ed)

As the line-break shows in the post content itself when loading the posts.

This PR resolves this issue while computing the line break on the client side.