### PR TITLE
refactor: remove duplicate password helpers and clean up password.js

### DIFF
--- a/packages/server/database/seed/users.js
+++ b/packages/server/database/seed/users.js
@@ -1,6 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 
-const { hashPassword } = require("../utils/password");
+const { hashPassword } = require("../../utils/password");
 
 /**
  * @param { import("knex").Knex } knex

--- a/packages/server/database/seed/users.js
+++ b/packages/server/database/seed/users.js
@@ -1,6 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 
-const { hashPassword } = require("../../helpers");
+const { hashPassword } = require("../utils/password");
 
 /**
  * @param { import("knex").Knex } knex

--- a/packages/server/helpers.js
+++ b/packages/server/helpers.js
@@ -47,9 +47,6 @@ const generateHexColor = () => {
   return (~~(random * (1 << 24))).toString(16);
 };
 
-
-
-
 /**
  * Sanitise username
  *

--- a/packages/server/helpers.js
+++ b/packages/server/helpers.js
@@ -54,16 +54,7 @@ const generateHexColor = () => {
  * @param {string} value password to be hashed
  * @returns Return hash password
  */
-const hashPassword = (value) => {
-  if (_.isEmpty(value)) {
-    return null;
-  }
 
-  const bcryptSaltRounds = 10;
-  const bcryptSalt = bcrypt.genSaltSync(bcryptSaltRounds);
-  const hashPassword = bcrypt.hashSync(value, bcryptSalt);
-  return hashPassword;
-};
 
 /**
  * Validate hashed pasword
@@ -72,17 +63,7 @@ const hashPassword = (value) => {
  * @param {string} hash hashed password
  * @returns {boolean} Return boolean value
  */
-const validatePassword = (password, hash) => {
-  if (_.isEmpty(password && hash)) {
-    return null;
-  }
 
-  if (!_.isString(password && hash)) {
-    return null;
-  }
-
-  return bcrypt.compareSync(password, hash);
-};
 
 /**
  * Sanitise username

--- a/packages/server/helpers.js
+++ b/packages/server/helpers.js
@@ -1,6 +1,5 @@
 const _ = require("lodash");
 const { validate: validateUUID } = require("uuid");
-const bcrypt = require("bcryptjs");
 
 /**
  * Check value is valid email
@@ -48,21 +47,7 @@ const generateHexColor = () => {
   return (~~(random * (1 << 24))).toString(16);
 };
 
-/**
- * Generate hased password
- *
- * @param {string} value password to be hashed
- * @returns Return hash password
- */
 
-
-/**
- * Validate hashed pasword
- *
- * @param {string} password string password
- * @param {string} hash hashed password
- * @returns {boolean} Return boolean value
- */
 
 
 /**
@@ -119,8 +104,6 @@ module.exports = {
   validEmail,
   validUUID,
   generateHexColor,
-  hashPassword,
-  validatePassword,
   sanitiseUsername,
   sanitiseURL,
   toSlug,

--- a/packages/server/tests/integration/v1/boards.spec.js
+++ b/packages/server/tests/integration/v1/boards.spec.js
@@ -5,7 +5,7 @@ import { faker } from "@faker-js/faker";
 
 const app = require("../../../app");
 const database = require("../../../database");
-const { hashPassword } = require("../../../helpers");
+const { hashPassword } = require("../../../utils/password");
 import { board as generateBoards } from "../../utils/generators";
 const { getUser } = require("../../utils/getUser");
 

--- a/packages/server/tests/integration/v1/roles.spec.js
+++ b/packages/server/tests/integration/v1/roles.spec.js
@@ -6,7 +6,7 @@ import { faker } from "@faker-js/faker";
 const app = require("../../../app");
 const database = require("../../../database");
 import { getUser } from "../../utils/getUser";
-const { hashPassword } = require("../../../helpers");
+const { hashPassword } = require("../../../utils/password");
 
 // Get all roles
 describe("GET /api/v1/roles", () => {

--- a/packages/server/tests/unit/helpers.test.js
+++ b/packages/server/tests/unit/helpers.test.js
@@ -2,11 +2,7 @@ import { describe, it, expect } from "vitest";
 import _ from "lodash";
 import generatePassword from "omgopass";
 
-import {
-  validEmail,
-  validUUID,
-  generateHexColor
-} from "../../helpers";
+import { validEmail, validUUID, generateHexColor } from "../../helpers";
 
 describe("validate email", () => {
   it('should be a valid email "yashu@codecarrot.net"', () => {

--- a/packages/server/tests/unit/helpers.test.js
+++ b/packages/server/tests/unit/helpers.test.js
@@ -5,9 +5,7 @@ import generatePassword from "omgopass";
 import {
   validEmail,
   validUUID,
-  generateHexColor,
-  hashPassword,
-  validatePassword,
+  generateHexColor
 } from "../../helpers";
 
 describe("validate email", () => {
@@ -154,35 +152,5 @@ describe("generateHexColor", () => {
     const result = /^#([a-fA-F0-9]){3}$|[a-fA-F0-9]{6}$/gi.test(color);
 
     expect(result).toBeTruthy();
-  });
-});
-
-describe("hashPassword and validatePassword", () => {
-  it("should not hash empty string as password", () => {
-    const hash = hashPassword("");
-
-    expect(hash).toEqual(null);
-  });
-
-  it("should validate hash random password", () => {
-    const password = generatePassword();
-    const hash = hashPassword(password);
-    const validPassword = validatePassword(password, hash);
-
-    expect(validPassword).toBeTruthy();
-  });
-
-  it("should validate hash random password with missing hash", () => {
-    const password = generatePassword();
-    const validPassword = validatePassword(password);
-
-    expect(validPassword).toEqual(null);
-  });
-
-  it("should validate hash random password with missing password", () => {
-    const hash = hashPassword("");
-    const validPassword = validatePassword("", hash);
-
-    expect(validPassword).toEqual(null);
   });
 });

--- a/packages/server/utils/password.js
+++ b/packages/server/utils/password.js
@@ -1,24 +1,24 @@
-// modules
 const bcrypt = require("bcryptjs");
 
 exports.hashPassword = (password) => {
-  if (password) {
-    const bcryptSaltRounds = 10;
-    const bcryptSalt = bcrypt.genSaltSync(bcryptSaltRounds);
-    const hashPassword = bcrypt.hashSync(password, bcryptSalt);
-
-    return hashPassword;
+  if (typeof password !== "string" || !password.trim()) {
+    return null;
   }
-  return undefined;
+
+  const bcryptSaltRounds = 10;
+  const bcryptSalt = bcrypt.genSaltSync(bcryptSaltRounds);
+  return bcrypt.hashSync(password, bcryptSalt);
 };
 
 exports.validatePassword = async (password, hash) => {
-  if (password) {
-    if (hash) {
-      const result = await bcrypt.compare(password, hash);
-      return result;
-    }
-    return undefined;
+  if (
+    typeof password !== "string" ||
+    typeof hash !== "string" ||
+    !password.trim() ||
+    !hash.trim()
+  ) {
+    return false;
   }
-  return undefined;
+
+  return await bcrypt.compare(password, hash);
 };

--- a/packages/server/utils/password.unit.test.js
+++ b/packages/server/utils/password.unit.test.js
@@ -7,7 +7,7 @@ const { hashPassword, validatePassword } = require("./password");
 test("Hash empty string as password", () => {
   const hash = hashPassword("");
 
-  expect(hash).toBeUndefined();
+  expect(hash).toBeNull();
 });
 
 test("Validate hash random password", async () => {
@@ -22,12 +22,12 @@ test("Validate hash random password with missing hash", async () => {
   const password = generatePassword();
   const validPassword = await validatePassword(password);
 
-  expect(validPassword).toBeUndefined();
+  expect(validPassword).toBe(false);
 });
 
 test("Validate hash random password with missing password", async () => {
   const hash = hashPassword("");
   const validPassword = await validatePassword(hash);
 
-  expect(validPassword).toBeUndefined();
+  expect(validPassword).toBe(false);
 });


### PR DESCRIPTION
### 🔧 What this PR does

- Removed duplicate `hashPassword` and `validatePassword` from `helpers.js`
- Centralized password logic in `utils/password.js`
- Cleaned up code:
  - Removed `lodash` dependency
  - Added consistent return values
  - Used `async/await` properly for password comparison
- Ensured all references now use only the `utils/password.js` helpers

Fixes [issue#945] (https://github.com/logchimp/logchimp/issues/945)