### PR TITLE
Fix: Prevent duplicate roadmaps from loading on initial fetch

### DIFF
--- a/packages/theme/src/pages/Roadmaps.vue
+++ b/packages/theme/src/pages/Roadmaps.vue
@@ -46,15 +46,21 @@ async function getRoadmaps() {
 
   try {
     const response = await getAllRoadmaps();
-    roadmaps.value = response.data.roadmaps;
 
-    if (response.data.roadmaps.length) {
-			roadmaps.value.push(...response.data.roadmaps);
-			page.value += 1;
-			state.value = "LOADED"
-		} else {
-			state.value = "COMPLETED";
-		}
+    const newRoadmaps = response.data.roadmaps;
+
+    if (newRoadmaps.length > 0) {
+      if (page.value === 1) {
+        roadmaps.value = newRoadmaps;
+      } else {
+        roadmaps.value.push(...newRoadmaps);
+      }
+
+      page.value += 1;
+      state.value = "LOADED";
+    } else {
+      state.value = "COMPLETED";
+    }
   } catch (err) {
     console.error(err);
     state.value = "ERROR";


### PR DESCRIPTION
This PR resolves an issue where the list of roadmaps was loading twice during the initial render, causing duplicated columns in the UI.

Changes made:

- Updated getRoadmaps method to conditionally push new data only on subsequent pages.
- Ensured roadmaps.value is replaced (not appended) on the first page load.


 Bug root cause:
The original logic always used roadmaps.value.push(...) without checking if it was the first page. This resulted in the same items being rendered multiple times on initial load.

 Result:
Now the roadmap list loads only once during the initial render and appends properly on scroll.
Related issue : [https://github.com/logchimp/logchimp/issues/967](url)