### PR TITLE
chore(docker): ignore node_modules to speed up build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,7 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+
+node_modules
+packages/*/node_modules
+


### PR DESCRIPTION
## Summary
Added `node_modules/` to `.dockerignore` to prevent copying unnecessary dependencies into Docker build context.

## Why
This reduces Docker image build time and size by excluding local dependencies that are reinstalled inside the container.

## Changes made
- Updated `.dockerignore` to include `node_modules/`

## Testing
- Ran `docker build` locally and confirmed `node_modules/` was not included in the build context.

## Notes for reviewer
This is a small development environment optimization and does not affect application runtime behavior.
