### PR TITLE
refactor: remove unused import of withDefaults in PostItem.vue and BreadcrumbItem.vue components

### DIFF
--- a/packages/theme/src/components/post/PostItem.vue
+++ b/packages/theme/src/components/post/PostItem.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, withDefaults } from "vue";
+import { computed, ref } from "vue";
 
 import { useTrim } from "../../hooks";
 

--- a/packages/theme/src/components/ui/breadcrumbs/BreadcrumbItem.vue
+++ b/packages/theme/src/components/ui/breadcrumbs/BreadcrumbItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { h, useSlots, defineProps } from "vue";
+import { h, useSlots } from "vue";
 import { RouterLink, type RouteLocationRaw } from "vue-router";
 
 const props = defineProps<{


### PR DESCRIPTION
### What does this PR do?

Since Vue 3.3+, defineProps and withDefaults are compiler macros and do not require importing from vue.
This PR removes those redundant imports to eliminate build warnings from @vue/compiler-sfc and keep the code aligned with current best practices.

### Changes
Removed import { defineProps, withDefaults } from 'vue' from <script setup> blocks.

Fixes  #1034 