### PR TITLE
fix: Board Badge width now fits content

### DIFF
--- a/packages/theme/src/components/board/BoardBadge.vue
+++ b/packages/theme/src/components/board/BoardBadge.vue
@@ -2,7 +2,7 @@
   <router-link
     v-if="showBoard"
     data-test="board-badge"
-    class="block select-none truncate"
+    class="block w-fit select-none truncate"
     :to="`/boards/${url}`"
   >
     <div class="flex items-center px-2.5 py-1 bg-(--color-gray-95) rounded-full">


### PR DESCRIPTION
**Fixes #1043** 

This PR resolves the issue where the Board Badge width extended based on the Post title length.

**Changes Made**
 - Added the `w-fit` utility class to `packages/theme/src/components/board/BoardBadge.vue` to make the badge width fit it's content.
