### PR TITLE
fix: server crash when signing in with the same credentials

### DIFF
--- a/packages/server/src/controllers/auth/setup.ts
+++ b/packages/server/src/controllers/auth/setup.ts
@@ -48,6 +48,10 @@ export async function setup(req, res, next) {
       name,
     });
 
+    // if user already exists, createUser returns null
+    if(!user)
+      return
+
     // set user as owner
     await database
       .update({

--- a/packages/server/src/controllers/auth/setup.ts
+++ b/packages/server/src/controllers/auth/setup.ts
@@ -49,8 +49,7 @@ export async function setup(req, res, next) {
     });
 
     // if user already exists, createUser returns null
-    if(!user)
-      return
+    if(!user) return;
 
     // set user as owner
     await database

--- a/packages/server/src/controllers/auth/signup.ts
+++ b/packages/server/src/controllers/auth/signup.ts
@@ -40,6 +40,10 @@ export async function signup(req, res, next) {
       password,
     });
 
+    // if user already exists, createUser returns null
+    if(!user)
+      return
+
     res.status(201).send({ user });
   } catch (err) {
     logger.log({

--- a/packages/server/src/controllers/auth/signup.ts
+++ b/packages/server/src/controllers/auth/signup.ts
@@ -41,8 +41,7 @@ export async function signup(req, res, next) {
     });
 
     // if user already exists, createUser returns null
-    if(!user)
-      return
+    if(!user) return;
 
     res.status(201).send({ user });
   } catch (err) {

--- a/packages/server/tests/integration/v1/auth/signup.spec.ts
+++ b/packages/server/tests/integration/v1/auth/signup.spec.ts
@@ -39,6 +39,23 @@ describe("POST /api/v1/auth/signup", () => {
     expect(user.email).toEqual(randomEmail);
   });
 
+  it("should not create new user and throws 'USER EXISTS'", async () => {
+    const randomEmail = faker.internet.email();
+
+    await supertest(app).post("/api/v1/auth/signup").send({
+      email: randomEmail,
+      password: "password",
+    });
+
+    const response = await supertest(app).post("/api/v1/auth/signup").send({
+      email: randomEmail,
+      password: "password",
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe("USER_EXISTS");
+  });
+
   it("should not be allow to create account", async () => {
     // set allowSignup to false in settings table
     await database


### PR DESCRIPTION
This PR fixes the authentication logic to safely handle repeated sign in attempts with the same credentials without crashing the server.

**Changes made in**
- `packages/server/src/controllers/auth/setup.ts`
- `packages/server/src/controllers/auth/signup.ts`