### PR TITLE
test(theme): add initial PageHeader test with Vitest

### DIFF
--- a/packages/theme/src/components/__tests__/PageHeader.test.ts
+++ b/packages/theme/src/components/__tests__/PageHeader.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("PageHeader component", () => {
+  it("renders without crashing", () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
#Summary
This PR adds a basic unit test for the `PageHeader` component using Vitest to validate the test setup in the `theme` package.

#Changes
- Added `packages/theme/src/components/__tests__/PageHeader.test.ts`
  - Simple smoke test to ensure the test runner and environment work.

# Why
- Ensures the testing framework (Vitest) is configured and working for future test coverage.
- Provides a minimal, reproducible example for writing more component tests.

# How to run tests locally
```bash
pnpm install
pnpm vitest
