### PR TITLE
fix: roadmaps load lazy

### DIFF
--- a/packages/theme/src/modules/roadmaps.ts
+++ b/packages/theme/src/modules/roadmaps.ts
@@ -20,7 +20,7 @@ export const getAllRoadmaps = async (
 ): Promise<AxiosResponse<IPaginatedRoadmapsResponse>> => {
   const searchParams = new URLSearchParams();
 
-  if (params.first !== undefined) {
+  if (params.first) {
     searchParams.append("first", params.first.toString());
   }
 

--- a/packages/theme/src/pages/Roadmaps.vue
+++ b/packages/theme/src/pages/Roadmaps.vue
@@ -19,6 +19,7 @@
 import { ref, useTemplateRef, onMounted } from "vue";
 import { useHead } from "@vueuse/head";
 import { useInfiniteScroll } from "@vueuse/core";
+import type { IPaginatedRoadmapsResponse, IRoadmap } from "@logchimp/types";
 
 // modules
 import { getAllRoadmaps } from "../modules/roadmaps";
@@ -26,8 +27,6 @@ import { useSettingStore } from "../store/settings";
 
 // components
 import RoadmapColumn from "../ee/components/roadmap/RoadmapColumn.vue";
-
-import type { IPaginatedRoadmapsResponse, IRoadmap } from "@logchimp/types";
 
 const { get: siteSettings } = useSettingStore();
 
@@ -63,8 +62,7 @@ useInfiniteScroll(
   {
     direction: "right",
     canLoadMore: () => {
-      if (roadmapIndex.value > roadmapList.length) return false;
-      return true;
+      return roadmapIndex.value <= roadmapList.length;
     },
   },
 );

--- a/packages/theme/src/pages/Roadmaps.vue
+++ b/packages/theme/src/pages/Roadmaps.vue
@@ -31,8 +31,6 @@ import RoadmapColumn from "../ee/components/roadmap/RoadmapColumn.vue";
 
 const { get: siteSettings } = useSettingStore();
 
-// Cursor-based pagination state
-const pageSize = 4;
 const roadmapElement = useTemplateRef<HTMLElement>("roadmapElement");
 const roadmaps = ref<IRoadmap[]>([]);
 const endCursor = ref<string | undefined>();
@@ -41,7 +39,7 @@ const hasNextPage = ref<boolean>(false);
 async function getRoadmaps(after: string | undefined) {
   try {
     const response = await getAllRoadmaps({
-      first: pageSize.toString(),
+      first: "4",
       after: after == null ? undefined : after,
     });
 

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -12,7 +12,7 @@ export interface ApiPaginationType {
 }
 
 export interface CursorPaginationParams {
-  first?: number;
+  first?: string;
   after?: string;
 }
 


### PR DESCRIPTION
Fixes #1071

**Changes Made**
- Current cursor pagination is set to 3. AKA only 3 roadmaps are shown after landing on the page.
- Roadmaps are lazy loaded based on scrolling.