### PR TITLE
bugfix: NODE_ENV is set before helper.ts

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,3 +1,6 @@
+// Set the default environment to be `development`
+process.env.NODE_ENV = process.env.NODE_ENV || "development";
+
 import express from "express";
 import cors from "cors";
 
@@ -15,9 +18,6 @@ if (!config) {
   );
   process.exit(1);
 }
-
-// Set the default environment to be `development`
-process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
 // contains key-value pairs of data submitted in the request body
 app.use(express.json());


### PR DESCRIPTION
PR fixes the control flow of the code where `packages/server/src/helper.ts` runs before `packages/server/src/app.ts` to sent `NODE_ENV`