### PR TITLE
fix: assign roadmap to post

### DIFF
--- a/packages/theme/src/components/board/BoardSuggestion.vue
+++ b/packages/theme/src/components/board/BoardSuggestion.vue
@@ -19,6 +19,7 @@ interface Props {
 }
 
 defineProps<Props>();
+defineEmits(["click"]);
 </script>
 
 <style lang='sass'>

--- a/packages/theme/src/pages/dashboard/posts/_slug/Index.vue
+++ b/packages/theme/src/pages/dashboard/posts/_slug/Index.vue
@@ -295,7 +295,9 @@ async function suggestRoadmap(event: Event) {
 function selectBoard(index: number) {
   const item = boards.suggestions[index];
 
-  Object.assign(post.board, item);
+  Object.assign(post, {
+    board: item,
+  });
   boards.search = "";
   boards.suggestions = [];
 }


### PR DESCRIPTION
Patches the existing issue where the roadmaps can't be assigned to a post.

**Changes made**
- `packages/theme/src/pages/dashboard/posts/_slug/Index.vue`

Closes https://github.com/logchimp/logchimp/issues/1129
