### PR TITLE
add: API build depends on DB health check

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,7 +42,8 @@ services:
       - /app/packages/server/dist
       - /app/packages/types/dist
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     networks:
       - dev-network
     environment:

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -24,7 +24,8 @@ services:
     image: ghcr.io/logchimp/logchimp/api:latest
     restart: unless-stopped
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       NODE_ENV: ${NODE_ENV:-production}
       PORT: ${API_PORT:-8000}


### PR DESCRIPTION
Instability affecting the production docker build has been fixed by adding DB health_check dependency for API