### PR TITLE
fix: early return in boardExists

### DIFF
--- a/packages/server/src/ee/middleware/boardExists.ts
+++ b/packages/server/src/ee/middleware/boardExists.ts
@@ -21,7 +21,15 @@ export async function boardExists(
 ) {
   const url = req.params.url;
 
-  const boardId = "boardId" in req.body ? validUUID(req.body?.boardId) : null;
+  const boardId = validUUID(req.body.boardId);
+
+  if (!boardId && !url) {
+    res.status(404).send({
+      message: error.api.boards.boardNotFound,
+      code: "BOARD_ID_OR_URL_MISSING",
+    });
+    return;
+  }
 
   const board = await database
     .select("boardId")


### PR DESCRIPTION
This is a hot-fix for the issue which allows, unintended update of a board map, when no parameters are passed.

Changes made

- `packages/server/src/ee/middleware/boardExists.ts`