### PR TITLE
bug: fixes lower and upper bound for limit and page

### DIFF
--- a/packages/server/src/helpers.ts
+++ b/packages/server/src/helpers.ts
@@ -134,13 +134,20 @@ const isDevTestEnv =
 
 function parseAndValidatePage(value?: string) {
   const n = value ? +value : NaN;
+  const PAGE_UPPER_LIMIT = 999999;
   // Default to page 1; coerce invalid/NaN/<=0 to 1
-  return !Number.isNaN(n) && n > 0 ? Math.floor(n) : 1;
+  return Math.min(
+    !Number.isNaN(n) && n > 0 ? Math.floor(n) : 1,
+    PAGE_UPPER_LIMIT,
+  );
 }
 
 function parseAndValidateLimit(value: string, max: number): number {
   const parsedLimit = value ? +value : NaN;
-  return value && !Number.isNaN(parsedLimit) ? Math.min(parsedLimit, max) : max;
+  return Math.max(
+    value && !Number.isNaN(parsedLimit) ? Math.min(parsedLimit, max) : max,
+    0,
+  );
 }
 
 export {


### PR DESCRIPTION
Fixes #1183 and #1184

**Changes made**
- `packages/server/src/helpers.ts`
- Number of `page(s)` is capped, to avoid _BIG_INTEGER_ERROR_
- Ensures limit is a non negative number.