### PR TITLE
Docs: add pnpm installation step to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,9 @@ We welcome contributions! To ensure your work doesn't conflict with ongoing work
 2. **Discuss your ideas with us in public channels (GitHub/Discord) BEFORE starting development** (No private DMs)
 3. Get approval from a core team member
 
+## Prerequisites
+- Node.js (>=18)
+- pnpm (install globally using `npm install -g pnpm`)
+
+
 This helps us align efforts and prevents duplicated or conflicting work.


### PR DESCRIPTION
Description:
While setting up the project locally, I faced an issue when running npm run server:dev.
The error was:
'pnpm' is not recognized as an internal or external command
This happened because pnpm is required but was not mentioned in the setup instructions.

What I changed ?
Updated the README.md to include a step for installing pnpm globally:
npm install -g pnpm
Clarified that dependencies should be installed using pnpm install.

Why this change is useful ?
New contributors might face the same issue and not know why npm run server:dev fails.
Adding this step makes the setup process smoother and prevents confusion.