### PR TITLE
refactor parseAndValidateLimit-helper.ts

### DIFF
--- a/packages/server/src/helpers.ts
+++ b/packages/server/src/helpers.ts
@@ -146,7 +146,9 @@ function parseAndValidatePage(value?: string) {
 function parseAndValidateLimit(value: string, max: number): number {
   const parsedLimit = value ? +value : NaN;
   return Math.max(
-    value && !Number.isNaN(parsedLimit) ? Math.min(parsedLimit, max) : max,
+    value && !Number.isNaN(parsedLimit)
+      ? Math.min(Math.floor(parsedLimit), max)
+      : max,
     0,
   );
 }

--- a/packages/server/tests/unit/helpers.test.ts
+++ b/packages/server/tests/unit/helpers.test.ts
@@ -349,7 +349,7 @@ describe("parseAndValidateLimit", () => {
     expect(parseAndValidateLimit("0", max)).toBe(0);
   });
 
-  it("accepts float values directly", () => {
-    expect(parseAndValidateLimit("7.5", max)).toBe(7.5);
+  it("floors a float value", () => {
+    expect(parseAndValidateLimit("7.5", max)).toBe(7);
   });
 });


### PR DESCRIPTION
Fixes `parseAndValidateLimit` in `helper.ts` so that it only returns whole number and not float value.
Rewrote 1 unit test associated to the change.