### PR TITLE
Refactor(board): check name to check slug

### DIFF
--- a/packages/server/src/controllers/post/create.ts
+++ b/packages/server/src/controllers/post/create.ts
@@ -1,5 +1,4 @@
 import type { Request, Response } from "express";
-import { nanoid } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import type {
   IApiErrorResponse,
@@ -12,7 +11,7 @@ import type {
 import database from "../../database";
 
 // utils
-import { validUUID } from "../../helpers";
+import { validUUID, generateNanoID as nanoid } from "../../helpers";
 import logger from "../../utils/logger";
 
 import error from "../../errorResponse.json";

--- a/packages/server/src/ee/controllers/v1/boards/checkName.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkName.ts
@@ -1,30 +1,24 @@
 import type { Request, Response } from "express";
-import type {
-  IApiErrorResponse,
-  TBoardCheckSlugBody,
-  TBoardCheckSlugResponse,
-  TPermission,
-} from "@logchimp/types";
+import type { TBoardCheckNameBody, TPermission } from "@logchimp/types";
 import database from "../../../../database";
 
 // utils
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 
-type ResponseBody = TBoardCheckSlugResponse | IApiErrorResponse;
-
-export async function checkSlug(
-  req: Request<unknown, unknown, TBoardCheckSlugBody>,
-  res: Response<ResponseBody>,
+export async function checkName(
+  req: Request<unknown, unknown, TBoardCheckNameBody>,
+  res: Response,
 ) {
+  logger.warning(
+    "This API will be deprecated in the upcoming major release. Use `check-slug` instead",
+  );
   // @ts-expect-error
   const permissions = req.user.permissions as TPermission[];
 
-  const slugUrl = req.body.url;
+  const name = req.body.name;
 
-  const checkPermission =
-    permissions.includes("board:create") ||
-    permissions.includes("board:update");
+  const checkPermission = permissions.includes("board:create");
   if (!checkPermission) {
     res.status(403).send({
       message: error.api.roles.notEnoughPermission,
@@ -33,15 +27,15 @@ export async function checkSlug(
     return;
   }
 
-  if (!slugUrl) {
+  if (!name) {
     res.status(400).send({
-      message: error.api.boards.urlMissing,
-      code: "BOARD_URL_MISSING",
+      message: error.api.boards.nameMissing,
+      code: "BOARD_NAME_MISSING",
     });
     return;
   }
 
-  const slimUrl = slugUrl
+  const slimUrl = name
     .replace(/[^\w]+/gi, "-")
     .trim()
     .toLowerCase();

--- a/packages/server/src/ee/controllers/v1/boards/checkName.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkName.ts
@@ -10,9 +10,10 @@ export async function checkName(
   req: Request<unknown, unknown, TBoardCheckNameBody>,
   res: Response,
 ) {
-  logger.warning(
-    "This API will be deprecated in the upcoming major release. Use `check-slug` instead",
+  logger.warn(
+    "`/api/v1/boards/check-name` API endpoint is deprecated and will be removed in next major release. Use `/api/v1/boards/check-slug` API endpoint.",
   );
+
   // @ts-expect-error
   const permissions = req.user.permissions as TPermission[];
 

--- a/packages/server/src/ee/controllers/v1/boards/checkName.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkName.ts
@@ -43,7 +43,7 @@ export async function checkName(
 
   try {
     const board = await database
-      .select()
+      .select<{ boardId: string }>("boardId")
       .from("boards")
       .where({
         url: slimUrl || null,

--- a/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import type { TBoardCheckNameBody, TPermission } from "@logchimp/types";
+import type { TBoardCheckSlugBody, TPermission } from "@logchimp/types";
 import database from "../../../../database";
 
 // utils
@@ -7,13 +7,13 @@ import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 
 export async function checkSlug(
-  req: Request<unknown, unknown, TBoardCheckNameBody>,
+  req: Request<unknown, unknown, TBoardCheckSlugBody>,
   res: Response,
 ) {
   // @ts-expect-error
   const permissions = req.user.permissions as TPermission[];
 
-  const name = req.body.name;
+  const slugUrl = req.body.url;
 
   const checkPermission = permissions.includes("board:create");
   if (!checkPermission) {
@@ -24,15 +24,15 @@ export async function checkSlug(
     return;
   }
 
-  if (!name) {
+  if (!slugUrl) {
     res.status(400).send({
-      message: error.api.boards.nameMissing,
-      code: "BOARD_NAME_MISSING",
+      message: error.api.boards.urlMissing,
+      code: "BOARD_URL_MISSING",
     });
     return;
   }
 
-  const slimUrl = name
+  const slimUrl = slugUrl
     .replace(/[^\w]+/gi, "-")
     .trim()
     .toLowerCase();

--- a/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
@@ -6,7 +6,7 @@ import database from "../../../../database";
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 
-export async function checkName(
+export async function checkSlug(
   req: Request<unknown, unknown, TBoardCheckNameBody>,
   res: Response,
 ) {

--- a/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
@@ -15,7 +15,9 @@ export async function checkSlug(
 
   const slugUrl = req.body.url;
 
-  const checkPermission = permissions.includes("board:create");
+  const checkPermission =
+    permissions.includes("board:create") ||
+    permissions.includes("board:update");
   if (!checkPermission) {
     res.status(403).send({
       message: error.api.roles.notEnoughPermission,

--- a/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
+++ b/packages/server/src/ee/controllers/v1/boards/checkSlug.ts
@@ -48,7 +48,7 @@ export async function checkSlug(
 
   try {
     const board = await database
-      .select()
+      .select<{ boardId: string }>("boardId")
       .from("boards")
       .where({
         url: slimUrl || null,

--- a/packages/server/src/ee/controllers/v1/boards/create.ts
+++ b/packages/server/src/ee/controllers/v1/boards/create.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { nanoid } from "nanoid";
+import { customAlphabet } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import type {
   IApiErrorResponse,
@@ -36,6 +36,7 @@ export async function create(
   }
 
   try {
+    const nanoid = customAlphabet("_0123456789abcdefghijklmnopqrstuvwxyz");
     const createBoard = await database
       .insert({
         boardId: uuidv4(),

--- a/packages/server/src/ee/controllers/v1/boards/create.ts
+++ b/packages/server/src/ee/controllers/v1/boards/create.ts
@@ -1,5 +1,4 @@
 import type { Request, Response } from "express";
-import { customAlphabet } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import type {
   IApiErrorResponse,
@@ -12,7 +11,10 @@ import type {
 import database from "../../../../database";
 
 // utils
-import { generateHexColor } from "../../../../helpers";
+import {
+  generateHexColor,
+  generateNanoID as nanoid,
+} from "../../../../helpers";
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 
@@ -36,7 +38,6 @@ export async function create(
   }
 
   try {
-    const nanoid = customAlphabet("_0123456789abcdefghijklmnopqrstuvwxyz");
     const createBoard = await database
       .insert({
         boardId: uuidv4(),

--- a/packages/server/src/ee/controllers/v1/boards/index.ts
+++ b/packages/server/src/ee/controllers/v1/boards/index.ts
@@ -2,7 +2,7 @@ export { create } from "./create";
 export { filter } from "./filter";
 export { get } from "./get";
 export { searchBoard } from "./searchBoard";
-export { checkName } from "./checkName";
+export { checkSlug } from "./checkSlug";
 export { boardByUrl } from "./boardByUrl";
 export { updateBoard } from "./updateBoard";
 export { deleteById } from "./deleteById";

--- a/packages/server/src/ee/controllers/v1/boards/index.ts
+++ b/packages/server/src/ee/controllers/v1/boards/index.ts
@@ -6,3 +6,6 @@ export { checkSlug } from "./checkSlug";
 export { boardByUrl } from "./boardByUrl";
 export { updateBoard } from "./updateBoard";
 export { deleteById } from "./deleteById";
+
+// DEPRECATED, will be removed
+export { checkName } from "./checkName";

--- a/packages/server/src/ee/controllers/v1/boards/index.ts
+++ b/packages/server/src/ee/controllers/v1/boards/index.ts
@@ -7,5 +7,6 @@ export { boardByUrl } from "./boardByUrl";
 export { updateBoard } from "./updateBoard";
 export { deleteById } from "./deleteById";
 
-// DEPRECATED, will be removed
+// --- Start: Deprecated, will be removed in next major release ---
 export { checkName } from "./checkName";
+// -- End: Deprecated ---

--- a/packages/server/src/ee/controllers/v1/boards/updateBoard.ts
+++ b/packages/server/src/ee/controllers/v1/boards/updateBoard.ts
@@ -27,6 +27,8 @@ export async function updateBoard(
   const permissions = req.user.permissions as TPermission[];
   // @ts-expect-error
   const boardId = req.board.boardId;
+  // @ts-expect-error
+  const boardUrl = req.board.url;
 
   const { name, url, color, view_voters, display } = req.body;
 
@@ -52,6 +54,22 @@ export async function updateBoard(
   }
 
   const slimUrl = url.replace(/\W+/gi, "-").trim().toLowerCase();
+
+  if (boardUrl !== slimUrl) {
+    const urlExists = await database
+      .select()
+      .from("boards")
+      .where({
+        url: slimUrl || null,
+      })
+      .first();
+    if (urlExists) {
+      return res.status(409).send({
+        message: error.api.boards.urlExists,
+        code: "BOARD_URL_EXISTS",
+      });
+    }
+  }
 
   try {
     const boards = await database

--- a/packages/server/src/ee/controllers/v1/roadmaps/create.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/create.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { nanoid } from "nanoid";
+import { customAlphabet } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import type {
   IApiErrorResponse,
@@ -43,12 +43,13 @@ export async function create(
   try {
     // get maximum index value of roadmap
     const roadmapIndex = await database.max("index").from("roadmaps").first();
+    const nanoid = customAlphabet("_0123456789abcdefghijklmnopqrstuvwxyz");
 
     const createRoadmap = await database
       .insert({
         id: uuidv4(),
         name: name || "new roadmap",
-        url: `new-roadmap-${nanoid(10).toLowerCase()}`,
+        url: `new-roadmap-${nanoid(10)}`,
         color: generateHexColor(),
         index: roadmapIndex.max + 1,
       })

--- a/packages/server/src/ee/controllers/v1/roadmaps/create.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/create.ts
@@ -1,5 +1,4 @@
 import type { Request, Response } from "express";
-import { customAlphabet } from "nanoid";
 import { v4 as uuidv4 } from "uuid";
 import type {
   IApiErrorResponse,
@@ -13,7 +12,10 @@ import type {
 import database from "../../../../database";
 
 // utils
-import { generateHexColor } from "../../../../helpers";
+import {
+  generateHexColor,
+  generateNanoID as nanoid,
+} from "../../../../helpers";
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 
@@ -43,7 +45,6 @@ export async function create(
   try {
     // get maximum index value of roadmap
     const roadmapIndex = await database.max("index").from("roadmaps").first();
-    const nanoid = customAlphabet("_0123456789abcdefghijklmnopqrstuvwxyz");
 
     const createRoadmap = await database
       .insert({

--- a/packages/server/src/ee/middleware/boardExists.ts
+++ b/packages/server/src/ee/middleware/boardExists.ts
@@ -32,7 +32,7 @@ export async function boardExists(
   }
 
   const board = await database
-    .select("boardId")
+    .select("boardId", "url")
     .from("boards")
     .where((builder) => {
       if (boardId) builder.where("boardId", boardId);

--- a/packages/server/src/ee/routes/v1/boards.ts
+++ b/packages/server/src/ee/routes/v1/boards.ts
@@ -40,4 +40,8 @@ router.patch("/boards", authRequired, boardExists, boards.updateBoard);
 
 router.delete("/boards", authRequired, boardExists, boards.deleteById);
 
+// DEPRECATED, will be removed
+
+router.post("/boards/check-name", authRequired, boards.checkName);
+
 export default router;

--- a/packages/server/src/ee/routes/v1/boards.ts
+++ b/packages/server/src/ee/routes/v1/boards.ts
@@ -34,7 +34,7 @@ router.get<ISearchBoardRequestParams>(
   boards.searchBoard,
 );
 
-router.post("/boards/check-name", authRequired, boards.checkName);
+router.post("/boards/check-slug", authRequired, boards.checkSlug);
 router.post("/boards", authRequired, boards.create);
 router.patch("/boards", authRequired, boardExists, boards.updateBoard);
 

--- a/packages/server/src/ee/routes/v1/boards.ts
+++ b/packages/server/src/ee/routes/v1/boards.ts
@@ -40,8 +40,8 @@ router.patch("/boards", authRequired, boardExists, boards.updateBoard);
 
 router.delete("/boards", authRequired, boardExists, boards.deleteById);
 
-// DEPRECATED, will be removed
-
+// --- Start: Deprecated, will be removed in next major release ---
 router.post("/boards/check-name", authRequired, boards.checkName);
+// -- End: Deprecated ---
 
 export default router;

--- a/packages/server/src/errorResponse.json
+++ b/packages/server/src/errorResponse.json
@@ -54,6 +54,7 @@
       "urlMissing": "Board url cannot be empty",
       "boardIdMissing": "Board ID missing",
       "exists": "Board already exists",
+      "urlExists": "Board url already exists",
       "boardNotFound": "Board not found"
     },
     "roadmaps": {

--- a/packages/server/src/helpers.ts
+++ b/packages/server/src/helpers.ts
@@ -3,6 +3,7 @@ import { validate as validateUUID } from "uuid";
 import fs from "fs";
 import { isEmail } from "validator";
 import { OFFSET_PAGINATION_UPPER_LIMIT } from "./constants";
+import { customAlphabet } from "nanoid";
 
 /**
  * Check value is valid email
@@ -163,6 +164,22 @@ function parseAndValidateLimit(value: string, max: number): number {
   return _value > 0 ? Math.min(Math.floor(_value), max) : max;
 }
 
+/**
+ * Random ID generator using nanoid.
+ * Returns random ID based on param length.
+ * @param {number} length
+ * @returns {string}
+ */
+function generateNanoID(length: number): string {
+  // Generate nanoid only with [_0-9a-z]
+  const allowedChars = "_0123456789abcdefghijklmnopqrstuvwxyz";
+  const nanoid = customAlphabet(
+    allowedChars,
+    Math.min(Math.max(length, 2), allowedChars.length),
+  );
+  return nanoid();
+}
+
 export {
   validEmail,
   validUUID,
@@ -176,4 +193,5 @@ export {
   isDevTestEnv,
   parseAndValidatePage,
   parseAndValidateLimit,
+  generateNanoID,
 };

--- a/packages/server/tests/integration/v1/boards.spec.ts
+++ b/packages/server/tests/integration/v1/boards.spec.ts
@@ -557,6 +557,29 @@ describe("PATCH /api/v1/boards", () => {
     );
   });
 
+  it("should throw error 'BOARD_URL_EXISTS'", async () => {
+    const { user: authUser } = await createUser();
+
+    const preExistingBoard = await generateBoards({}, true);
+    const board = await generateBoards({}, true);
+
+    await createRoleWithPermissions(authUser.userId, ["board:update"], {
+      roleName: "Board Patcher",
+    });
+
+    const response = await supertest(app)
+      .patch("/api/v1/boards")
+      .set("Authorization", `Bearer ${authUser.authToken}`)
+      .send({
+        boardId: board.boardId,
+        url: preExistingBoard.url,
+      });
+
+    expect(response.headers["content-type"]).toContain("application/json");
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe("BOARD_URL_EXISTS");
+  });
+
   it("should UPDATE board", async () => {
     const board: BoardInsertRecord = await generateBoards({}, true);
     const newBoard: BoardInsertRecord = await generateBoards({}, false);

--- a/packages/server/tests/integration/v1/boards.spec.ts
+++ b/packages/server/tests/integration/v1/boards.spec.ts
@@ -557,7 +557,7 @@ describe("PATCH /api/v1/boards", () => {
     );
   });
 
-  it("should throw error 'BOARD_URL_EXISTS'", async () => {
+  it("should throw error 'BOARD_URL_EXISTS' for updating same board URL", async () => {
     const { user: authUser } = await createUser();
 
     const preExistingBoard = await generateBoards({}, true);

--- a/packages/server/tests/unit/helpers.test.ts
+++ b/packages/server/tests/unit/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   validUUIDs,
   parseAndValidatePage,
   parseAndValidateLimit,
+  generateNanoID,
 } from "../../src/helpers";
 
 describe("validate email", () => {
@@ -351,5 +352,28 @@ describe("parseAndValidateLimit", () => {
 
   it("floors a float value", () => {
     expect(parseAndValidateLimit("7.5", max)).toBe(7);
+  });
+});
+
+describe("generateNanoID", () => {
+  const nanoIdRegex = /^[_0-9a-z]+$/;
+  it("should create a random ID of length 2 if length <= 2", () => {
+    const randomId = generateNanoID(Number.MIN_SAFE_INTEGER);
+    expect(randomId.length).toBe(2);
+    expect(randomId).toMatch(nanoIdRegex);
+  });
+
+  it("should create a random ID of length 37 if length >= 37", () => {
+    const randomId = generateNanoID(Number.MAX_SAFE_INTEGER);
+    expect(randomId.length).toBe(37);
+    expect(randomId).toMatch(nanoIdRegex);
+  });
+
+  it("should create a random ID only using [_a-z0-9]", () => {
+    for (let length = 2; length < 10; length++) {
+      const randomId = generateNanoID(length);
+      expect(randomId.length).toBe(length);
+      expect(randomId).toMatch(nanoIdRegex);
+    }
   });
 });

--- a/packages/server/tests/utils/generators.ts
+++ b/packages/server/tests/utils/generators.ts
@@ -1,18 +1,15 @@
 import { faker } from "@faker-js/faker";
 import { v4 as uuidv4, v4 as uuid } from "uuid";
 import generatePassword from "omgopass";
-import { customAlphabet } from "nanoid";
 
 import {
   generateHexColor,
   sanitiseUsername,
   sanitiseURL,
   toSlug,
+  generateNanoID as nanoid,
 } from "../../src/helpers";
 import database from "../../src/database";
-
-// Create nanoid with only [_0-9a-z]
-const nanoid = customAlphabet("_0123456789abcdefghijklmnopqrstuvwxyz");
 
 const user = () => {
   return {

--- a/packages/server/tests/utils/generators.ts
+++ b/packages/server/tests/utils/generators.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { v4 as uuidv4, v4 as uuid } from "uuid";
 import generatePassword from "omgopass";
-import { nanoid } from "nanoid";
+import { customAlphabet } from "nanoid";
 
 import {
   generateHexColor,
@@ -10,6 +10,9 @@ import {
   toSlug,
 } from "../../src/helpers";
 import database from "../../src/database";
+
+// Create nanoid with only [_0-9a-z]
+const nanoid = customAlphabet("_0123456789abcdefghijklmnopqrstuvwxyz");
 
 const user = () => {
   return {
@@ -41,8 +44,7 @@ async function roadmap(roadmap?: Partial<RoadmapArgs>, insertToDb = false) {
   const name = roadmap?.name || faker.commerce.productName();
 
   const id = uuid();
-  const url =
-    roadmap?.url || `${sanitiseURL(name)}-${nanoid(10).toLowerCase()}`;
+  const url = roadmap?.url || `${sanitiseURL(name)}-${nanoid(10)}`;
   const index = faker.number.int({ min: 1, max: 100000 });
   const color = generateHexColor();
   const display = faker.datatype.boolean();

--- a/packages/theme/src/components/ui/input/HelperText.vue
+++ b/packages/theme/src/components/ui/input/HelperText.vue
@@ -1,0 +1,7 @@
+<template>
+  <div
+    class="text-sm text-neutral-700"
+  >
+    <slot />
+  </div>
+</template>

--- a/packages/theme/src/ee/components/dashboard/boards/BoardSettingsForm/SlugInputField.vue
+++ b/packages/theme/src/ee/components/dashboard/boards/BoardSettingsForm/SlugInputField.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, watch, computed } from "vue";
+import { ref, reactive, watch } from "vue";
 import { CheckCircle2 as CheckCircle } from "lucide-vue";
 import { watchDebounced } from "@vueuse/core";
 

--- a/packages/theme/src/ee/components/dashboard/boards/BoardSettingsForm/SlugInputField.vue
+++ b/packages/theme/src/ee/components/dashboard/boards/BoardSettingsForm/SlugInputField.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { ref, reactive, watch } from "vue";
+import { CheckCircle2 as CheckCircle } from "lucide-vue";
+import { watchDebounced } from "@vueuse/core";
+
+import { checkBoardSlug } from "../../../../modules/boards";
+
+import HelperText from "../../../../../components/ui/input/HelperText.vue";
+import LText from "../../../../../components/ui/input/LText.vue";
+import Loader from "../../../../../components/icons/Loader.vue";
+
+interface Props {
+  currentValue: string;
+}
+const props = defineProps<Props>();
+const emit = defineEmits<(e: "update", value: string) => void>();
+
+const value = ref<string>(props.currentValue || "");
+type TDefaultState = {
+  available: boolean | undefined;
+  loading: boolean;
+};
+const DEFAULT_STATE: TDefaultState = {
+  available: undefined,
+  loading: false,
+};
+const state = reactive(DEFAULT_STATE);
+
+watchDebounced(
+  () => value.value,
+  async (newValue: string) => {
+    console.log("debounce ->");
+    console.log("new Value: ", newValue);
+    const current = props.currentValue;
+    console.log("current: ", current);
+
+    if (!current) {
+      value.value = "";
+      state.available = undefined;
+      return;
+    }
+
+    console.log("");
+
+    if (newValue === current) return;
+    state.available = undefined;
+    state.loading = true;
+
+    try {
+      const response = await checkBoardSlug(newValue);
+      state.available = response.data.available;
+    } catch (err) {
+      console.error(err);
+    } finally {
+      state.loading = false;
+    }
+  },
+  { debounce: 600 },
+);
+
+async function validateBoardUrl(event: KeyboardEvent) {
+  const key = event.key;
+
+  // allow common shortcuts (copy/paste/select all, etc.)
+  if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+  // allow letters, numbers, underscore, and hyphen; plus navigation/edit keys
+  const allowed =
+    /^[a-zA-Z0-9_-]$/.test(key) ||
+    [
+      "Backspace",
+      "Delete",
+      "ArrowLeft",
+      "ArrowRight",
+      "Tab",
+      "Home",
+      "End",
+    ].includes(key);
+
+  if (!allowed) {
+    event.preventDefault();
+  }
+}
+
+watch(
+  () => value.value,
+  (newValue: string) => {
+    emit("update", newValue);
+  },
+);
+
+// Fail-safe in case `value` ref is not able to access `props.currentValue` directly
+watch(
+  () => props.currentValue,
+  (newValue: string) => {
+    value.value = newValue;
+  },
+);
+</script>
+
+<template>
+  <div class="grid gap-y-1.5">
+    <l-text
+      v-model="value"
+      label="Slug"
+      placeholder="Board slug url"
+      class="!mb-0"
+      @keydown="validateBoardUrl"
+    />
+    <HelperText>
+      Alphabets, numbers or underscore are allowed.
+    </HelperText>
+
+    <!-- Loading / Available / Not available states -->
+    <HelperText
+      :class="[
+        'flex items-center gap-x-1 font-medium transition-opacity',
+        value !== currentValue ? 'opacity-100' : 'opacity-0'
+      ]"
+      aria-hidden="true"
+    >
+      <template v-if="state.loading">
+        <Loader class="spinner stroke-neutral-800 size-4" />
+        Loading...
+      </template>
+      <template v-else-if="state.available">
+        <CheckCircle aria-hidden="true" class="size-4 stroke-green-600" />
+        Available
+      </template>
+      <template v-else-if="state.available === false">
+        <CheckCircle aria-hidden="true" class="size-4 stroke-red-500" />
+        Not available
+      </template>
+    </HelperText>
+  </div>
+</template>

--- a/packages/theme/src/ee/components/dashboard/boards/BoardSettingsForm/SlugInputField.vue
+++ b/packages/theme/src/ee/components/dashboard/boards/BoardSettingsForm/SlugInputField.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, watch } from "vue";
+import { ref, reactive, watch, computed } from "vue";
 import { CheckCircle2 as CheckCircle } from "lucide-vue";
 import { watchDebounced } from "@vueuse/core";
 
@@ -29,18 +29,9 @@ const state = reactive(DEFAULT_STATE);
 watchDebounced(
   () => value.value,
   async (newValue: string) => {
-    console.log("debounce ->");
-    console.log("new Value: ", newValue);
     const current = props.currentValue;
-    console.log("current: ", current);
 
-    if (!current) {
-      value.value = "";
-      state.available = undefined;
-      return;
-    }
-
-    console.log("");
+    emit("update", newValue);
 
     if (newValue === current) return;
     state.available = undefined;
@@ -80,19 +71,16 @@ async function validateBoardUrl(event: KeyboardEvent) {
   if (!allowed) {
     event.preventDefault();
   }
-}
 
-watch(
-  () => value.value,
-  (newValue: string) => {
-    emit("update", newValue);
-  },
-);
+  const target = event.target as HTMLInputElement;
+  value.value = target.value.toLowerCase();
+}
 
 // Fail-safe in case `value` ref is not able to access `props.currentValue` directly
 watch(
   () => props.currentValue,
   (newValue: string) => {
+    if (value.value) return;
     value.value = newValue;
   },
 );

--- a/packages/theme/src/ee/modules/boards.ts
+++ b/packages/theme/src/ee/modules/boards.ts
@@ -4,7 +4,7 @@ import type {
   IFilterBoardResponseBody,
   IGetBoardsRequestQuery,
   IGetBoardsResponseBody,
-  TBoardCheckNameResponse,
+  TBoardCheckSlugResponse,
   TBoardCreateRequestBody,
   TBoardCreateResponseBody,
   IBoardUpdateRequestBody,
@@ -177,18 +177,18 @@ export const deleteBoard = async (
 };
 
 /**
- * Check board name
+ * Check if board slug exists
  */
 export const checkBoardSlug = async (
-  name: string,
-): Promise<AxiosResponse<TBoardCheckNameResponse>> => {
+  url: string,
+): Promise<AxiosResponse<TBoardCheckSlugResponse>> => {
   const { authToken } = useUserStore();
 
   return await axios({
     method: "POST",
     url: `${VITE_API_URL}/api/v1/boards/check-slug`,
     data: {
-      name,
+      url,
     },
     headers: {
       Authorization: `Bearer ${authToken}`,

--- a/packages/theme/src/ee/modules/boards.ts
+++ b/packages/theme/src/ee/modules/boards.ts
@@ -5,6 +5,7 @@ import type {
   IGetBoardsRequestQuery,
   IGetBoardsResponseBody,
   TBoardCheckSlugResponse,
+  TBoardCheckNameResponse,
   TBoardCreateRequestBody,
   TBoardCreateResponseBody,
   IBoardUpdateRequestBody,
@@ -177,6 +178,27 @@ export const deleteBoard = async (
 };
 
 /**
+ * Check board name
+ * DEPRECATED, will be removed
+ */
+export const checkBoardName = async (
+  name: string,
+): Promise<AxiosResponse<TBoardCheckNameResponse>> => {
+  const { authToken } = useUserStore();
+
+  return await axios({
+    method: "POST",
+    url: `${VITE_API_URL}/api/v1/boards/check-name`,
+    data: {
+      name,
+    },
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+};
+
+/*
  * Check if board slug exists
  */
 export const checkBoardSlug = async (

--- a/packages/theme/src/ee/modules/boards.ts
+++ b/packages/theme/src/ee/modules/boards.ts
@@ -179,14 +179,14 @@ export const deleteBoard = async (
 /**
  * Check board name
  */
-export const checkBoardName = async (
+export const checkBoardSlug = async (
   name: string,
 ): Promise<AxiosResponse<TBoardCheckNameResponse>> => {
   const { authToken } = useUserStore();
 
   return await axios({
     method: "POST",
-    url: `${VITE_API_URL}/api/v1/boards/check-name`,
+    url: `${VITE_API_URL}/api/v1/boards/check-slug`,
     data: {
       name,
     },

--- a/packages/theme/src/ee/pages/dashboard/boards/Settings.vue
+++ b/packages/theme/src/ee/pages/dashboard/boards/Settings.vue
@@ -85,7 +85,7 @@ import { router } from "../../../../router";
 import {
   getBoardByUrl,
   updateBoard,
-  checkBoardName,
+  checkBoardSlug,
 } from "../../../modules/boards";
 import { useUserStore } from "../../../../store/user";
 import { useDashboardBoards } from "../../../store/dashboard/boards";
@@ -149,7 +149,7 @@ async function validateBoardUrl(event: KeyboardEvent) {
   urlAvailableError.value = false;
 
   try {
-    const response = await checkBoardName(board.url);
+    const response = await checkBoardSlug(board.url);
     if (!response.data.available) {
       urlAvailableError.value = true;
     }

--- a/packages/theme/src/ee/pages/dashboard/boards/Settings.vue
+++ b/packages/theme/src/ee/pages/dashboard/boards/Settings.vue
@@ -38,17 +38,23 @@
           <color-input v-model="board.color" />
         </div>
 
-        <div class="form-column flex">
-          <l-text
-            v-model="slugUrl"
-            label="Slug"
-            placeholder="Board slug url"
-            :error="{
-              show: urlAvailableError,
-              message: 'Not available'
-            }"
-            @keydown="validateBoardUrl"
-          />
+        <div class="form-column">
+          <div class="grid gap-y-1.5">
+            <l-text
+              v-model="slugUrl"
+              label="Slug"
+              placeholder="Board slug url"
+              :error="{
+                show: urlAvailableError,
+                message: 'Not available'
+              }"
+              class="!mb-0"
+              @keydown="validateBoardUrl"
+            />
+            <HelperText>
+              Alphabets, numbers or underscore are allowed.
+            </HelperText>
+          </div>
         </div>
       </div>
     </div>
@@ -94,6 +100,7 @@ import { useDashboardBoards } from "../../../store/dashboard/boards";
 // components
 import Button from "../../../../components/ui/Button.vue";
 import LText from "../../../../components/ui/input/LText.vue";
+import HelperText from "../../../../components/ui/HelperText.vue";
 import ToggleItem from "../../../../components/ui/input/ToggleItem.vue";
 import ColorInput from "../../../../components/ui/ColorInput.vue";
 import Breadcrumbs from "../../../../components/Breadcrumbs.vue";

--- a/packages/theme/src/ee/pages/dashboard/boards/Settings.vue
+++ b/packages/theme/src/ee/pages/dashboard/boards/Settings.vue
@@ -41,7 +41,7 @@
         <div class="form-column">
           <SlugInputField
             :current-value="board.url"
-            @update="(value) => board.url = value"
+            @update="(value) => (boardSlug = value)"
           />
         </div>
       </div>
@@ -73,6 +73,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, defineAsyncComponent } from "vue";
 import { useHead } from "@vueuse/head";
+import type { IBoardUpdateRequestBody } from "@logchimp/types";
 
 // modules
 import { router } from "../../../../router";
@@ -96,7 +97,7 @@ const SlugInputField = defineAsyncComponent(
     ),
 );
 
-const board = reactive({
+const board = reactive<IBoardUpdateRequestBody>({
   boardId: "",
   name: "",
   url: "",
@@ -104,6 +105,7 @@ const board = reactive({
   view_voters: false,
   display: false,
 });
+const boardSlug = ref("");
 const saveButtonLoading = ref(false);
 
 const { permissions } = useUserStore();
@@ -116,14 +118,18 @@ const updateBoardPermissionDisabled = computed(() => {
 async function update() {
   saveButtonLoading.value = true;
   try {
-    const response = await updateBoard({
+    const body = {
       boardId: board.boardId,
       color: board.color,
       name: board.name,
       url: board.url,
       view_voters: board.view_voters,
       display: board.display,
-    });
+    };
+    if (boardSlug.value) {
+      body.url = boardSlug.value;
+    }
+    const response = await updateBoard(body);
 
     dashboardBoards.updateBoard(response.data.board);
     router.push("/dashboard/boards");

--- a/packages/types/src/board.ts
+++ b/packages/types/src/board.ts
@@ -49,6 +49,16 @@ export type TBoardCheckSlugResponse = {
   readonly available: boolean;
 };
 
+export type TBoardCheckNameBody = {
+  // DEPRECATED, will be removed
+  name: string;
+};
+
+export type TBoardCheckNameResponse = {
+  // DEPRECATED, will be removed
+  readonly available: boolean;
+};
+
 export type TBoardCreateRequestBody = {
   name?: string;
   display?: boolean;

--- a/packages/types/src/board.ts
+++ b/packages/types/src/board.ts
@@ -41,11 +41,11 @@ export interface IGetBoardsByUrlResponseBody {
   board: IBoardPrivate;
 }
 
-export type TBoardCheckNameBody = {
-  name: string;
+export type TBoardCheckSlugBody = {
+  url: string;
 };
 
-export type TBoardCheckNameResponse = {
+export type TBoardCheckSlugResponse = {
   readonly available: boolean;
 };
 

--- a/packages/types/src/board.ts
+++ b/packages/types/src/board.ts
@@ -49,13 +49,19 @@ export type TBoardCheckSlugResponse = {
   readonly available: boolean;
 };
 
+/**
+ * @deprecated will be removed in next major release.
+ * Use `/api/v1/boards/check-slug` API endpoint.
+ */
 export type TBoardCheckNameBody = {
-  // DEPRECATED, will be removed
   name: string;
 };
 
+/**
+ * @deprecated will be removed in next major release.
+ * Use `/api/v1/boards/check-slug` API endpoint.
+ */
 export type TBoardCheckNameResponse = {
-  // DEPRECATED, will be removed
   readonly available: boolean;
 };
 


### PR DESCRIPTION
- Renamed `checkName` → `checkSlug` and it's respective affected areas.
- Board URL is now validated for availability before update.
- Added Debounce for checking board url availability.
- Restricted nanoid generation only to [a-z0-9_-].
- `checkSlug` will also take `board:update` as permission.
- Added integration tests for `check-slug` and update board.
- Added `checkName` for backward compatibility.