### PR TITLE
fix: added vertical scroll per column and removed from whole section #1324

### DIFF
--- a/packages/theme/src/ee/components/roadmap/RoadmapColumn.vue
+++ b/packages/theme/src/ee/components/roadmap/RoadmapColumn.vue
@@ -4,7 +4,7 @@
       <color-dot :color="roadmap.color" />
       <div data-test="roadmap-name" class="text-sm text-(--color-gray-60)">{{ roadmap.name }}</div>
     </header>
-    <div data-test="roadmap-column" class="rounded-md bg-(--color-gray-95) p-3 flex-grow">
+    <div data-test="roadmap-column" class="rounded-md bg-(--color-gray-95) p-3 flex-grow overflow-y-auto h-[350px]">
       <roadmap-post-card
         v-for="post in posts"
         :key="post.postId"

--- a/packages/theme/src/pages/Roadmaps.vue
+++ b/packages/theme/src/pages/Roadmaps.vue
@@ -12,7 +12,7 @@
       v-for="roadmap in roadmaps"
       :key="roadmap.id"
       :roadmap="roadmap"
-       class="h-[500px] overflow-y-auto"
+       
     />
   </div>
 </template>


### PR DESCRIPTION
added "overflow-y-hidden" to the roadmaps section so it don't scroll vertically and 
"h-[500px] overflow-y-auto" to individual column 

https://github.com/user-attachments/assets/9cb7cdeb-485c-4f15-b4cf-be37ed0d4eb3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Roadmap columns now have a fixed height with internal vertical scrolling, making long lists easier to navigate without expanding the page layout.
  * The Roadmaps page disables vertical scrolling while preserving horizontal scrolling, keeping the view stable when browsing wide content.
  * Overall layout adjustments improve readability and consistency when roadmap content exceeds the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->