### PR TITLE
added a check, if offline: oninfinite() not called    #1342

### DIFF
--- a/packages/theme/src/components/ui/InfiniteScroll.vue
+++ b/packages/theme/src/components/ui/InfiniteScroll.vue
@@ -76,6 +76,7 @@ watch(
 
 function executeInfiniteScroll() {
   if (props.state === "COMPLETED" || props.state === "ERROR") return;
+    if (!navigator.onLine) return;
   props.onInfinite();
 }
 


### PR DESCRIPTION
Previously, the infinite scroll component would continue calling onInfinite() even when the user was offline. This lead to unnecessary API errors, performance issues, or potential crashes.

Now, the component checks navigator.onLine before triggering onInfinite(). If the network is offline, no API calls are made, preventing repeated errors and improving stability.

This change applies to all places where infinite scroll is used, not just the roadmaps page