### PR TITLE
fix(theme): avoid sort API call when dragging to same position

### DIFF
--- a/packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue
+++ b/packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue
@@ -24,7 +24,7 @@
       :list="dashboardRoadmaps.roadmaps"
       group="roadmap"
       handle=".grip-handler"
-      item-key="roadmap"
+      item-key="id"
       :move="moveItem"
       @start="drag = true"
       @end="initialiseSort"
@@ -73,6 +73,20 @@ const sort = ref<ISortRoadmapRequestBody>({
   },
 });
 const drag = ref(false);
+// Track UI (zero-based) indices to detect no-op drags reliably
+const uiFromIndex = ref<number>(-1);
+const uiToIndex = ref<number>(-1);
+const hasPendingSort = ref<boolean>(false);
+
+function resetSortState() {
+  hasPendingSort.value = false;
+  uiFromIndex.value = -1;
+  uiToIndex.value = -1;
+  sort.value = {
+    from: { id: "", index: 0 },
+    to: { id: "", index: 0 },
+  };
+}
 
 function moveItem(
   event: VueDraggableEvent<
@@ -83,6 +97,7 @@ function moveItem(
   // Guard: ensure relatedContext.element exists
   if (!event.relatedContext?.element) {
     console.warn("Cannot sort: relatedContext.element is undefined");
+    resetSortState();
     return false;
   }
 
@@ -97,28 +112,49 @@ function moveItem(
     id: event.relatedContext.element.id,
     index: event.draggedContext.index + 1,
   };
+
+  // Save UI indices (zero-based) for accurate no-op detection
+  uiFromIndex.value = event.draggedContext.index;
+  uiToIndex.value = event.draggedContext.futureIndex;
+  hasPendingSort.value = true;
 }
 
 async function initialiseSort() {
   try {
-    // Validate sort data before sending to server
-    if (!sort.value.from.id || !sort.value.to.id) {
-      console.error("Invalid sort data: missing roadmap IDs");
-      drag.value = false;
+    // If move was cancelled or we don't have fresh indices, skip
+    if (!hasPendingSort.value || uiFromIndex.value < 0 || uiToIndex.value < 0) {
+      return;
+    }
+    // Skip API call if the UI position hasn't changed
+    if (uiFromIndex.value === uiToIndex.value) {
+      resetSortState();
       return;
     }
 
-    // Skip API call if the order hasn't changed
-    if (sort.value.from.index === sort.value.to.index) {
-      drag.value = false;
+    // Backfill missing IDs using current list positions (failsafe)
+    const fromIdx = uiFromIndex.value;
+    const toIdx = uiToIndex.value;
+    const list = dashboardRoadmaps.roadmaps as unknown as Array<{ id: string }>;
+    if (!sort.value.to.id && list[fromIdx]) {
+      sort.value.to.id = list[fromIdx].id;
+    }
+    if (!sort.value.from.id && list[toIdx]) {
+      sort.value.from.id = list[toIdx].id;
+    }
+
+    // Validate sort data before sending to server
+    if (!sort.value.from.id || !sort.value.to.id) {
+      console.error("Invalid sort data: missing roadmap IDs");
+      resetSortState();
       return;
     }
 
     const response = await sortRoadmap(sort.value);
 
     if (response.status === 200) {
-      drag.value = false;
-      dashboardRoadmaps.sortRoadmap(sort.value.from.index, sort.value.to.index);
+      // Update local store with zero-based indices captured from UI
+      dashboardRoadmaps.sortRoadmap(uiFromIndex.value, uiToIndex.value);
+      resetSortState();
     }
   } catch (err) {
     console.error("Error sorting roadmaps:", err);


### PR DESCRIPTION
- Guard undefined relatedContext.element
- Validate IDs before sending
- Skip API call when order unchanged

Fixes #1370

This PR is part of Hacktoberfest. If needed, please add the ‘hacktoberfest-accepted’ label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of drag-and-drop sorting in the roadmap table view.
  * Prevented invalid moves when related item data is missing; logs a warning and resets sort state.
  * Avoided unintended reordering by skipping actions when source and target UI positions are identical.
  * Added safer index tracking and validation to reduce sorting errors and mismatches.
  * Ensured drag state is reliably cleared after success or failure, avoiding stuck UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->