### PR TITLE
fix(theme/roadmaps): roadmaps section vertically scrollable

### DIFF
--- a/packages/theme/src/ee/components/roadmap/RoadmapColumn.vue
+++ b/packages/theme/src/ee/components/roadmap/RoadmapColumn.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex flex-col gap-2.5">
+  <div class="flex flex-col gap-2.5 h-full min-h-0">
     <header data-test="roadmap-header" class="flex items-center gap-x-1.5">
       <color-dot :color="roadmap.color" />
       <div data-test="roadmap-name" class="text-sm text-(--color-gray-60)">{{ roadmap.name }}</div>
     </header>
-    <div data-test="roadmap-column" class="rounded-md bg-(--color-gray-95) p-3 flex-grow">
+    <div data-test="roadmap-column" class="rounded-md bg-(--color-gray-95) p-3 flex-grow min-h-0 overflow-y-auto">
       <roadmap-post-card
         v-for="post in posts"
         :key="post.postId"

--- a/packages/theme/src/pages/Roadmaps.vue
+++ b/packages/theme/src/pages/Roadmaps.vue
@@ -4,7 +4,7 @@
     v-if="roadmaps.length > 0"
     ref="roadmapElement"
     :class="[
-      'overflow-x-auto h-[500px]',
+      'overflow-x-auto h-[500px] overflow-y-hidden',
       'grid grid-flow-col gap-x-4 md:gap-x-6 auto-cols-[minmax(22rem,24rem)]',
     ]"
   >


### PR DESCRIPTION
Closes https://github.com/logchimp/logchimp/issues/1324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in the Roadmap view to prevent unexpected vertical scroll and double scrollbars.
  * Ensured roadmap columns scroll smoothly within their containers without affecting the entire page.
* **Style**
  * Adjusted layout sizing to maintain full-height columns and consistent content visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->