### PR TITLE
fix(theme/roadmap): refer roadmaps `item-key` to unique identifier

### DIFF
--- a/packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue
+++ b/packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue
@@ -24,7 +24,7 @@
       :list="dashboardRoadmaps.roadmaps"
       group="roadmap"
       handle=".grip-handler"
-      item-key="roadmap"
+      item-key="id"
       :move="moveItem"
       @start="drag = true"
       @end="initialiseSort"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop reliability in the roadmap table view by using more stable item identification.
  * Prevents occasional mis-ordering, duplication, or items snapping back after reordering.
  * Ensures reordered items persist correctly across refreshes.
  * Reduces visual glitches for a smoother reordering experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->