### PR TITLE
Fix: display LogChimp version in dashboard sidebar (#1084)

### DIFF
--- a/packages/theme/src/layout/Viewer.vue
+++ b/packages/theme/src/layout/Viewer.vue
@@ -5,7 +5,10 @@
       <router-view />
 
       <div class="mt-8 mb-4 px-3 lg:px-6">
-        <power-by v-if="settingsStore.get.isPoweredBy" />
+        <PowerBy v-if="settingsStore.get.isPoweredBy" />
+        <div class="text-sm text-gray-500 mt-2">
+          LogChimp v{{ version }}
+        </div>
       </div>
     </div>
   </div>
@@ -17,6 +20,9 @@ import { useSettingStore } from "../store/settings";
 // components
 import Header from "../components/Header.vue";
 import PowerBy from "../components/PowerBy.vue";
+
+// Import LogChimp version
+import { version } from "../../package.json"; // adjust path if needed
 
 const settingsStore = useSettingStore();
 </script>


### PR DESCRIPTION
Added display of LogChimp version at the bottom of the dashboard page. Improves user awareness of the current version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Viewer now shows the current app version alongside the powered-by information, making it easy to confirm which version you're using. Appears in the Viewer layout footer next to the existing attribution, providing quick diagnostics and support reference.
* **Refactor**
  * Standardized component usage for the powered-by display to align with naming conventions; no user-facing behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->