### PR TITLE
character limit added to title in post creation form

### DIFF
--- a/.config/lefthook.yml
+++ b/.config/lefthook.yml
@@ -23,7 +23,7 @@ pre-commit:
     - run: |
         if [ -x "$(command -v pnpm)" ]; then
           pnpm biome format --write {staged_files}
-        else 
+        else
           pkgx +nodejs.org@20 +pnpm.io \
             pnpm biome format --write {staged_files}
         fi

--- a/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
+++ b/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
@@ -36,7 +36,12 @@
             placeholder="Name of the feature"
             :error="postFieldError"
             @hide-error="hideTitleError"
+            class="!mb-1"
           />
+
+          <HelperText :isError="post.title.length > MAX_TITLE_LENGTH">
+            {{ MAX_TITLE_LENGTH - post.title.length }} characters
+          </HelperText>
 
           <l-textarea
             :model-value="post.contentMarkdown ?? undefined"
@@ -93,6 +98,7 @@ import { useUserStore } from "../../../../store/user";
 import { useDashboardPosts } from "../../../../store/dashboard/posts";
 
 // components
+import HelperText from "../../../../components/ui/input/HelperText.vue";
 import Button from "../../../../components/ui/Button.vue";
 import LText from "../../../../components/ui/input/LText.vue";
 import LTextarea from "../../../../components/ui/input/LTextarea.vue";
@@ -106,6 +112,7 @@ import SearchBoardDropdown from "../../../../ee/components/dashboard/boards/Sear
 import type { TCurrentBoard } from "../../../../ee/components/dashboard/boards/SearchBoardDropdown/search";
 import type { TCurrentRoadmap } from "../../../../ee/components/dashboard/roadmap/SearchRoadmapDropdown/search";
 import type { FormFieldErrorType } from "../../../ui/input/formBaseProps";
+import { MAX_TITLE_LENGTH } from "../../../../constants";
 
 const { permissions } = useUserStore();
 const dashboardPosts = useDashboardPosts();
@@ -137,7 +144,7 @@ function hideTitleError(event: FormFieldErrorType) {
 }
 
 async function updatePostHandler() {
-  if (!post.title.trim()) {
+  if (!post.title.trim() || post.title.length > MAX_TITLE_LENGTH) {
     postFieldError.show = true;
     postFieldError.message = "Please enter a valid post title";
     return;

--- a/packages/theme/src/components/ui/input/HelperText.vue
+++ b/packages/theme/src/components/ui/input/HelperText.vue
@@ -1,7 +1,21 @@
 <template>
-  <div
-    class="text-sm text-neutral-700"
-  >
+  <div class="text-xs text-right" :class="textColorClass">
+
     <slot />
   </div>
 </template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps({
+  isError: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const textColorClass = computed(() =>
+  props.isError ? "input-error-message" : "text-neutral-500",
+);
+</script>

--- a/packages/theme/src/constants.ts
+++ b/packages/theme/src/constants.ts
@@ -8,3 +8,5 @@ export const VITE_API_URL =
 export const IS_SELF_HOSTED =
   window.__APP_ENV__?.VITE_IS_SELF_HOSTED === "true" ||
   import.meta.env.VITE_IS_SELF_HOSTED === "true";
+
+export const MAX_TITLE_LENGTH = 100;


### PR DESCRIPTION
this PR fixes issue: #1391 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live character counter for post titles showing remaining characters (limit 100)
  * Helper text shown below Title to surface counts and messages

* **Improvements**
  * Stricter title validation preventing empty or overly long titles with inline feedback
  * Helper text right-aligned and switches to error color when needed
  * Minor spacing adjustment to the Title input for tighter layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->