### PR TITLE
Feat: Add Cursor pagination (with offset) for filterPost api

### DIFF
--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -61,7 +61,7 @@ export async function filterPost(
   }
 
   const { first: _first, page, after, created, limit } = query.data;
-  const first = req.query?.limit ? limit : _first;
+  const first = limit ?? _first ?? GET_POSTS_FILTER_COUNT;
 
   const boardId = validUUIDs(req.body.boardId || []);
   const roadmapId = validUUID(req.body.roadmapId);

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -45,6 +45,12 @@ export async function filterPost(
   req: Request<unknown, unknown, IFilterPostRequestBody>,
   res: Response<ResponseBody>,
 ) {
+  if (req.query?.page || req.query?.limit) {
+    logger.warn(
+      "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",
+    );
+  }
+
   const query = querySchema.safeParse(req.query);
   if (!query.success) {
     return res.status(400).json({

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -201,7 +201,7 @@ async function buildPostsQuery({
   queryBuilder = queryBuilder.orderBy("createdAt", created);
 
   if (after) {
-    queryBuilder = queryBuilder.limit(first).offset(1);
+    queryBuilder = queryBuilder.limit(first);
   } else {
     const offset = page ? first * (page - 1) : 0;
     queryBuilder = queryBuilder.offset(offset).limit(first);

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -64,6 +64,13 @@ export async function filterPost(
   const { first: _first, page, after, created, limit } = query.data;
   const first = limit ?? _first ?? GET_POSTS_FILTER_COUNT;
 
+  if (after && !validUUID(after)) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid cursor format",
+    });
+  }
+
   const boardId = validUUIDs(req.body.boardId || []);
   const roadmapId = validUUID(req.body.roadmapId);
   // @ts-expect-error

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -26,6 +26,7 @@ import { GET_POSTS_FILTER_COUNT } from "../../constants";
 const querySchema = z.object({
   first: z.coerce
     .string()
+    .default(String(GET_POSTS_FILTER_COUNT))
     .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
   page: z.coerce
     .string()

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -51,7 +51,7 @@ const bodySchema = z.object({
   boardId: z
     .array(z.string())
     .optional()
-    .transform((value) => validUUIDs(value) || []),
+    .transform((value) => (Array.isArray(value) ? validUUIDs(value) : [])),
   roadmapId: z
     .string()
     .optional()

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -61,7 +61,7 @@ export async function filterPost(
   }
 
   const { first: _first, page, after, created, limit } = query.data;
-  const first = limit ?? _first ?? GET_POSTS_FILTER_COUNT;
+  const first = req.query?.limit ? limit : _first;
 
   if (after && !validUUID(after)) {
     return res.status(400).json({

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -26,7 +26,6 @@ import { GET_POSTS_FILTER_COUNT } from "../../constants";
 const querySchema = z.object({
   first: z.coerce
     .string()
-    .default(String(GET_POSTS_FILTER_COUNT))
     .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
   page: z.coerce
     .string()

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -191,7 +191,7 @@ async function buildPostsQuery({
     if (cursorPost) {
       queryBuilder = queryBuilder.where(
         "createdAt",
-        created === "ASC" ? ">=" : "<=",
+        created === "ASC" ? ">" : "<",
         cursorPost.createdAt,
       );
     }

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -86,6 +86,13 @@ export async function filterPost(
       roadmapId,
     });
 
+    if (page && response.length === 0) {
+      return res.status(200).json({
+        status: { code: 200, type: "success" },
+        posts: [],
+        results: [],
+      });
+    }
     // Enrich posts with board, roadmap, and votes
     const posts: IPost[] = [];
     for (const post of response) {

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -204,7 +204,7 @@ async function buildPostsQuery({
     queryBuilder = queryBuilder.limit(first).offset(1);
   } else {
     const offset = page ? first * (page - 1) : 0;
-    queryBuilder = queryBuilder.limit(first).offset(offset);
+    queryBuilder = queryBuilder.offset(offset).limit(first);
   }
 
   return queryBuilder;

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -582,7 +582,7 @@ describe("POST /api/v1/posts/get", () => {
       const lastId = res1.body.results[2].postId;
 
       const res2 = await supertest(app)
-        .get("/api/v1/posts/get")
+        .post("/api/v1/posts/get")
         .send({ boardId: [board.boardId] })
         .query({
           first: 3,

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -21,29 +21,6 @@ import { GET_POSTS_FILTER_COUNT } from "../../../src/constants";
 
 // Get posts with filters
 describe("POST /api/v1/posts/get", () => {
-  let authUser: any;
-  let board: any;
-  let roadmap: any;
-
-  beforeAll(async () => {
-    const userData = await createUser({ isVerified: true });
-    authUser = userData.user;
-    board = await generateBoard({}, true);
-    roadmap = await generateRoadmap({}, true);
-
-    // Generate 15 posts for pagination
-    for (let i = 0; i < 15; i++) {
-      await generatePost(
-        {
-          userId: authUser.userId,
-          boardId: board.boardId,
-          roadmapId: roadmap.id,
-        },
-        true,
-      );
-    }
-  });
-
   it("should use default page=1 and default limit when no filters are provided", async () => {
     const { user: authUser } = await createUser({ isVerified: true });
     const board = await generateBoard({}, true);
@@ -424,6 +401,29 @@ describe("POST /api/v1/posts/get", () => {
   });
 
   describe("Cursor Pagination", () => {
+    let authUser: any;
+    let board: any;
+    let roadmap: any;
+
+    beforeAll(async () => {
+      const userData = await createUser({ isVerified: true });
+      authUser = userData.user;
+      board = await generateBoard({}, true);
+      roadmap = await generateRoadmap({}, true);
+
+      // Generate 15 posts for pagination
+      for (let i = 0; i < 15; i++) {
+        await generatePost(
+          {
+            userId: authUser.userId,
+            boardId: board.boardId,
+            roadmapId: roadmap.id,
+          },
+          true,
+        );
+      }
+    });
+
     it("should return default first page (no after param)", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
@@ -597,6 +597,29 @@ describe("POST /api/v1/posts/get", () => {
     });
   });
   describe("Offset Pagination", () => {
+    let authUser: any;
+    let board: any;
+    let roadmap: any;
+
+    beforeAll(async () => {
+      const userData = await createUser({ isVerified: true });
+      authUser = userData.user;
+      board = await generateBoard({}, true);
+      roadmap = await generateRoadmap({}, true);
+
+      // Generate 15 posts for pagination
+      for (let i = 0; i < 15; i++) {
+        await generatePost(
+          {
+            userId: authUser.userId,
+            boardId: board.boardId,
+            roadmapId: roadmap.id,
+          },
+          true,
+        );
+      }
+    });
+
     it("should support offset pagination via page param", async () => {
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
@@ -607,9 +630,6 @@ describe("POST /api/v1/posts/get", () => {
 
       expect(page1.status).toBe(200);
       expect(page2.status).toBe(200);
-
-      expect(page1.body.page_info).toBeUndefined();
-
       const ids1 = page1.body.posts.map((p: IPost) => p.postId);
       const ids2 = page2.body.posts.map((p: IPost) => p.postId);
 

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -445,7 +445,7 @@ describe("POST /api/v1/posts/get", () => {
     });
 
     it("should default to cursor pagination return default list when no '?first=' param", async () => {
-      const res = await supertest(app).get("/api/v1/posts/get");
+      const res = await supertest(app).post("/api/v1/posts/get");
 
       const firstItem: IPost = res.body.posts[0];
       const lastItem: IPost = res.body.posts[res.body.posts.length - 1];
@@ -560,7 +560,7 @@ describe("POST /api/v1/posts/get", () => {
     });
 
     it("should handle empty '?after=' param gracefully", async () => {
-      const res = await supertest(app).get("/api/v1/posts/get").query({
+      const res = await supertest(app).post("/api/v1/posts/get").query({
         after: "",
       });
 
@@ -574,7 +574,7 @@ describe("POST /api/v1/posts/get", () => {
 
     it("should handle cursor pagination correctly", async () => {
       const res1 = await supertest(app)
-        .get("/api/v1/posts/get")
+        .post("/api/v1/posts/get")
         .query({ first: 3 });
       expect(res1.headers["content-type"]).toContain("application/json");
       const lastId = res1.body.results[2].postId;

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -64,7 +64,7 @@ describe("POST /api/v1/posts/get", () => {
     // Now request page 2 explicitly to ensure default was page 1
     const resPage2 = await supertest(app)
       .post("/api/v1/posts/get")
-      .query({ page: 2 });
+      .send({ page: 2 });
     expect(resPage2.headers["content-type"]).toContain("application/json");
     expect(resPage2.status).toBe(200);
 
@@ -238,12 +238,10 @@ describe("POST /api/v1/posts/get", () => {
 
     const page0 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "" })
-      .query({ limit: 2, page: 1 });
+      .send({ boardId: [board.boardId], userId: "", limit: 2, page: 1 });
     const page1 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "" })
-      .query({ limit: 2, page: 2 });
+      .send({ boardId: [board.boardId], userId: "", limit: 2, page: 2 });
 
     expect(page0.status).toBe(200);
     expect(page1.status).toBe(200);
@@ -309,8 +307,8 @@ describe("POST /api/v1/posts/get", () => {
 
     const asc = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "" })
-      .query({ created: "ASC", limit: 10, page: 1 });
+      .send({ boardId: [board.boardId], userId: "", limit: 10, page: 1 })
+      .query({ created: "ASC" });
 
     expect(asc.headers["content-type"]).toContain("application/json");
     expect(asc.status).toBe(200);
@@ -628,13 +626,13 @@ describe("POST /api/v1/posts/get", () => {
     it("should support offset pagination via page param", async () => {
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 1, created: "ASC" });
+        .send({ boardId: [board.boardId], limit: 5, page: 1 })
+        .query({ created: "ASC" });
 
       const page2 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 2, created: "ASC" });
+        .send({ boardId: [board.boardId], limit: 5, page: 2 })
+        .query({ created: "ASC" });
 
       expect(page1.status).toBe(200);
       expect(page2.status).toBe(200);
@@ -648,18 +646,15 @@ describe("POST /api/v1/posts/get", () => {
     it("should coerce page=0 or -1 to page=1", async () => {
       const page0 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 0 });
+        .send({ boardId: [board.boardId], limit: 5, page: 0 });
 
       const pageNeg1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: -1 });
+        .send({ boardId: [board.boardId], limit: 5, page: -1 });
 
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 1 });
+        .send({ boardId: [board.boardId], limit: 5, page: 1 });
 
       const ids0 = page0.body.posts.map((p: IPost) => p.postId);
       const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
@@ -672,8 +667,7 @@ describe("POST /api/v1/posts/get", () => {
     it("should return empty posts when '?page=1000'", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ page: 1000 });
+        .send({ boardId: [board.boardId], page: 1000 });
 
       expect(res.status).toBe(200);
       expect(res.body.posts).toHaveLength(0);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -469,8 +469,8 @@ describe("POST /api/v1/posts/get", () => {
       expect(typeof start_cursor).toBe("string");
       expect(typeof end_cursor).toBe("string");
 
-      expect(res.body.page_info.start_cursor).toBe(firstItem.slug);
-      expect(res.body.page_info.end_cursor).toBe(lastItem.slug);
+      expect(res.body.page_info.start_cursor).toBe(firstItem.postId);
+      expect(res.body.page_info.end_cursor).toBe(lastItem.postId);
 
       // total_count and total_pages should be present in cursor mode
       expect(typeof res.body.total_count).toBe("number");
@@ -486,7 +486,7 @@ describe("POST /api/v1/posts/get", () => {
       expect(firstPage.body.page_info.count).toBeLessThanOrEqual(5);
 
       const endCursor = firstPage.body.page_info.end_cursor;
-      const firstPageSlugs = firstPage.body.posts.map((p: IPost) => p.slug);
+      const firstPageId = firstPage.body.posts.map((p: IPost) => p.postId);
 
       const secondPage = await supertest(app)
         .post("/api/v1/posts/get")
@@ -501,9 +501,9 @@ describe("POST /api/v1/posts/get", () => {
       expect(secondPage.body.page_info).toBeDefined();
       expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
 
-      const page2Slugs = secondPage.body.posts.map((p: IPost) => p.slug);
+      const secondPageId = secondPage.body.posts.map((p: IPost) => p.postId);
 
-      const overlap = page2Slugs.filter((s) => firstPageSlugs.includes(s));
+      const overlap = secondPageId.filter((s) => firstPageId.includes(s));
       expect(overlap.length).toBe(0);
 
       expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
@@ -577,7 +577,7 @@ describe("POST /api/v1/posts/get", () => {
         .get("/api/v1/posts/get")
         .query({ first: 3 });
       expect(res1.headers["content-type"]).toContain("application/json");
-      const lastId = res1.body.results[2].userId;
+      const lastId = res1.body.results[2].postId;
 
       const res2 = await supertest(app).get("/api/v1/posts/get").query({
         first: 3,
@@ -591,8 +591,8 @@ describe("POST /api/v1/posts/get", () => {
       expect(res2.body.page_info.end_cursor).toBeTypeOf("string");
       expect(res2.body.page_info.start_cursor).toBeTypeOf("string");
 
-      const ids1 = res1.body.results.map((p: IPost) => p.slug);
-      const ids2 = res2.body.results.map((p: IPost) => p.slug);
+      const ids1 = res1.body.results.map((p: IPost) => p.postId);
+      const ids2 = res2.body.results.map((p: IPost) => p.postId);
       expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
     });
   });
@@ -610,8 +610,8 @@ describe("POST /api/v1/posts/get", () => {
 
       expect(page1.body.page_info).toBeUndefined();
 
-      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
-      const ids2 = page2.body.posts.map((p: IPost) => p.slug);
+      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
+      const ids2 = page2.body.posts.map((p: IPost) => p.postId);
 
       const overlap = ids1.filter((id: string) => ids2.includes(id));
       expect(overlap.length).toBe(0);
@@ -628,9 +628,9 @@ describe("POST /api/v1/posts/get", () => {
         .post("/api/v1/posts/get")
         .send({ limit: 5, page: 1, boardId: [board.boardId] });
 
-      const ids0 = page0.body.posts.map((p: IPost) => p.slug);
-      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.slug);
-      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
+      const ids0 = page0.body.posts.map((p: IPost) => p.postId);
+      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
+      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
 
       expect(ids0).toEqual(ids1);
       expect(idsNeg1).toEqual(ids1);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -408,8 +408,8 @@ describe("POST /api/v1/posts/get", () => {
       board = await generateBoard({}, true);
       roadmap = await generateRoadmap({}, true);
 
-      // Generate 20 posts for pagination
-      for (let i = 0; i < 20; i++) {
+      // Generate 15 posts for pagination
+      for (let i = 0; i < 15; i++) {
         await generatePost(
           {
             userId: authUser.userId,

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -408,8 +408,8 @@ describe("POST /api/v1/posts/get", () => {
       board = await generateBoard({}, true);
       roadmap = await generateRoadmap({}, true);
 
-      // Generate 15 posts for pagination
-      for (let i = 0; i < 15; i++) {
+      // Generate 20 posts for pagination
+      for (let i = 0; i < 20; i++) {
         await generatePost(
           {
             userId: authUser.userId,

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import supertest from "supertest";
 import { faker } from "@faker-js/faker";
 import { v4 as uuid } from "uuid";
@@ -17,9 +17,33 @@ import {
 } from "../../utils/generators";
 import { createRoleWithPermissions } from "../../utils/createRoleWithPermissions";
 import { isActive } from "../../../src/cache";
+import { GET_POSTS_FILTER_COUNT } from "../../../src/constants";
 
 // Get posts with filters
 describe("POST /api/v1/posts/get", () => {
+  let authUser: any;
+  let board: any;
+  let roadmap: any;
+
+  beforeAll(async () => {
+    const userData = await createUser({ isVerified: true });
+    authUser = userData.user;
+    board = await generateBoard({}, true);
+    roadmap = await generateRoadmap({}, true);
+
+    // Generate 15 posts for pagination
+    for (let i = 0; i < 15; i++) {
+      await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+    }
+  });
+
   it("should use default page=1 and default limit when no filters are provided", async () => {
     const { user: authUser } = await createUser({ isVerified: true });
     const board = await generateBoard({}, true);
@@ -397,6 +421,229 @@ describe("POST /api/v1/posts/get", () => {
     expect(found).toBeDefined();
     expect(found.voters).toBeDefined();
     expect(found.voters.viewerVote).toBeUndefined();
+  });
+
+  describe("Cursor Pagination", () => {
+    it("should return default first page (no after param)", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ boardId: [board.boardId], created: "DESC" });
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/json");
+
+      const posts: IPost[] = res.body.posts;
+      expect(Array.isArray(posts)).toBeTruthy();
+      expect(posts.length).toBeGreaterThan(0);
+
+      const pageInfo = res.body.page_info;
+      expect(pageInfo).toBeDefined();
+      expect(typeof pageInfo.start_cursor).toBe("string");
+      expect(typeof pageInfo.end_cursor).toBe("string");
+      expect(typeof pageInfo.has_next_page).toBe("boolean");
+      expect(typeof pageInfo.current_page).toBe("number");
+    });
+
+    it("should default to cursor pagination return default list when no '?first=' param", async () => {
+      const res = await supertest(app).get("/api/v1/posts/get");
+
+      const firstItem: IPost = res.body.posts[0];
+      const lastItem: IPost = res.body.posts[res.body.posts.length - 1];
+
+      expect(res.headers["content-type"]).toContain("application/json");
+      expect(res.status).toBe(200);
+
+      expect(res.body.results).toHaveLength(GET_POSTS_FILTER_COUNT);
+      expect(res.body.posts).toHaveLength(GET_POSTS_FILTER_COUNT);
+      expect(Array.isArray(res.body.results)).toBeTruthy();
+      expect(Array.isArray(res.body.posts)).toBeTruthy();
+
+      expect(res.body.page_info).toBeDefined();
+      expect(typeof res.body.page_info.count).toBe("number");
+      expect(typeof res.body.page_info.current_page).toBe("number");
+      expect(typeof res.body.page_info.has_next_page).toBe("boolean");
+
+      // start_cursor and end_cursor are either string (uuid) or null when no data
+      const { start_cursor, end_cursor } = res.body.page_info;
+
+      expect(typeof start_cursor).toBe("string");
+      expect(typeof end_cursor).toBe("string");
+
+      expect(res.body.page_info.start_cursor).toBe(firstItem.slug);
+      expect(res.body.page_info.end_cursor).toBe(lastItem.slug);
+
+      // total_count and total_pages should be present in cursor mode
+      expect(typeof res.body.total_count).toBe("number");
+    });
+
+    it("should paginate using 'after' param and increase current_page", async () => {
+      const firstPage = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+
+      expect(firstPage.status).toBe(200);
+      expect(firstPage.body.page_info).toBeDefined();
+      expect(firstPage.body.page_info.count).toBeLessThanOrEqual(5);
+
+      const endCursor = firstPage.body.page_info.end_cursor;
+      const firstPageSlugs = firstPage.body.posts.map((p: IPost) => p.slug);
+
+      const secondPage = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({
+          first: 5,
+          after: endCursor,
+          created: "ASC",
+          boardId: [board.boardId],
+        });
+
+      expect(secondPage.status).toBe(200);
+      expect(secondPage.body.page_info).toBeDefined();
+      expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
+
+      const page2Slugs = secondPage.body.posts.map((p: IPost) => p.slug);
+
+      const overlap = page2Slugs.filter((s) => firstPageSlugs.includes(s));
+      expect(overlap.length).toBe(0);
+
+      expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should compute has_next_page correctly for small first value", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 3, created: "DESC", boardId: [board.boardId] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.page_info).toBeDefined();
+      expect(res.body.page_info.count).toBeLessThanOrEqual(3);
+      expect(res.body.page_info.has_next_page).toBe(true);
+    });
+
+    it("should throw VALIDATION_ERROR for invalid 'after' param", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, after: "not-a-uuid", boardId: [board.boardId] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should sort posts by 'created' ASC and DESC", async () => {
+      const ascRes = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+      const descRes = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, created: "DESC", boardId: [board.boardId] });
+
+      expect(ascRes.status).toBe(200);
+      expect(descRes.status).toBe(200);
+
+      const ascDates = ascRes.body.posts.map(
+        (p: IPost) => new Date(p.createdAt),
+      );
+      const descDates = descRes.body.posts.map(
+        (p: IPost) => new Date(p.createdAt),
+      );
+
+      for (let i = 0; i < ascDates.length - 1; i++) {
+        expect(ascDates[i].getTime()).toBeLessThanOrEqual(
+          ascDates[i + 1].getTime(),
+        );
+      }
+      for (let i = 0; i < descDates.length - 1; i++) {
+        expect(descDates[i].getTime()).toBeGreaterThanOrEqual(
+          descDates[i + 1].getTime(),
+        );
+      }
+    });
+
+    it("should handle empty '?after=' param gracefully", async () => {
+      const res = await supertest(app).get("/api/v1/posts/get").query({
+        after: "",
+      });
+
+      expect(res.headers["content-type"]).toContain("application/json");
+      expect(res.status).toBe(400);
+
+      expect(res.body.code).toBe("VALIDATION_ERROR");
+      expect(res.body.message).toBe("Invalid query parameters");
+      expect(res.body.errors?.[0]?.message).toMatch(/invalid uuid/gi);
+    });
+
+    it("should handle cursor pagination correctly", async () => {
+      const res1 = await supertest(app)
+        .get("/api/v1/posts/get")
+        .query({ first: 3 });
+      expect(res1.headers["content-type"]).toContain("application/json");
+      const lastId = res1.body.results[2].userId;
+
+      const res2 = await supertest(app).get("/api/v1/posts/get").query({
+        first: 3,
+        after: lastId,
+      });
+
+      expect(res2.headers["content-type"]).toContain("application/json");
+      expect(res2.status).toBe(200);
+
+      expect(res2.body.results).toHaveLength(3);
+      expect(res2.body.page_info.end_cursor).toBeTypeOf("string");
+      expect(res2.body.page_info.start_cursor).toBeTypeOf("string");
+
+      const ids1 = res1.body.results.map((p: IPost) => p.slug);
+      const ids2 = res2.body.results.map((p: IPost) => p.slug);
+      expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
+    });
+  });
+  describe("Offset Pagination", () => {
+    it("should support offset pagination via page param", async () => {
+      const page1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 1, boardId: [board.boardId], created: "ASC" });
+      const page2 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 2, boardId: [board.boardId], created: "ASC" });
+
+      expect(page1.status).toBe(200);
+      expect(page2.status).toBe(200);
+
+      expect(page1.body.page_info).toBeUndefined();
+
+      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
+      const ids2 = page2.body.posts.map((p: IPost) => p.slug);
+
+      const overlap = ids1.filter((id: string) => ids2.includes(id));
+      expect(overlap.length).toBe(0);
+    });
+
+    it("should coerce page=0 or -1 to page=1", async () => {
+      const page0 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 0, boardId: [board.boardId] });
+      const pageNeg1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: -1, boardId: [board.boardId] });
+      const page1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 1, boardId: [board.boardId] });
+
+      const ids0 = page0.body.posts.map((p: IPost) => p.slug);
+      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.slug);
+      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
+
+      expect(ids0).toEqual(ids1);
+      expect(idsNeg1).toEqual(ids1);
+    });
+
+    it("should return empty posts when '?page=1000'", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ page: 1000, boardId: [board.boardId] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.posts).toHaveLength(0);
+    });
   });
 });
 

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -479,7 +479,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should paginate using 'after' param and increase current_page", async () => {
       const firstPage = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, created: "ASC" });
 
       expect(firstPage.status).toBe(200);
       expect(firstPage.body.page_info).toBeDefined();
@@ -490,12 +491,8 @@ describe("POST /api/v1/posts/get", () => {
 
       const secondPage = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({
-          first: 5,
-          after: endCursor,
-          created: "ASC",
-          boardId: [board.boardId],
-        });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, after: endCursor, created: "ASC" });
 
       expect(secondPage.status).toBe(200);
       expect(secondPage.body.page_info).toBeDefined();
@@ -512,7 +509,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should compute has_next_page correctly for small first value", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 3, created: "DESC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 3, created: "DESC" });
 
       expect(res.status).toBe(200);
       expect(res.body.page_info).toBeDefined();
@@ -523,7 +521,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should throw VALIDATION_ERROR for invalid 'after' param", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, after: "not-a-uuid", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, after: "not-a-uuid" });
 
       expect(res.status).toBe(400);
       expect(res.body.code).toBe("VALIDATION_ERROR");
@@ -532,10 +531,13 @@ describe("POST /api/v1/posts/get", () => {
     it("should sort posts by 'created' ASC and DESC", async () => {
       const ascRes = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, created: "ASC" });
+
       const descRes = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, created: "DESC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, created: "DESC" });
 
       expect(ascRes.status).toBe(200);
       expect(descRes.status).toBe(200);
@@ -575,14 +577,19 @@ describe("POST /api/v1/posts/get", () => {
     it("should handle cursor pagination correctly", async () => {
       const res1 = await supertest(app)
         .post("/api/v1/posts/get")
+        .send({ boardId: [board.boardId] })
         .query({ first: 3 });
+
       expect(res1.headers["content-type"]).toContain("application/json");
       const lastId = res1.body.results[2].postId;
 
-      const res2 = await supertest(app).get("/api/v1/posts/get").query({
-        first: 3,
-        after: lastId,
-      });
+      const res2 = await supertest(app)
+        .get("/api/v1/posts/get")
+        .send({ boardId: [board.boardId] })
+        .query({
+          first: 3,
+          after: lastId,
+        });
 
       expect(res2.headers["content-type"]).toContain("application/json");
       expect(res2.status).toBe(200);
@@ -623,10 +630,13 @@ describe("POST /api/v1/posts/get", () => {
     it("should support offset pagination via page param", async () => {
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 1, boardId: [board.boardId], created: "ASC" });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 1, created: "ASC" });
+
       const page2 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 2, boardId: [board.boardId], created: "ASC" });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 2, created: "ASC" });
 
       expect(page1.status).toBe(200);
       expect(page2.status).toBe(200);
@@ -640,13 +650,18 @@ describe("POST /api/v1/posts/get", () => {
     it("should coerce page=0 or -1 to page=1", async () => {
       const page0 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 0, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 0 });
+
       const pageNeg1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: -1, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: -1 });
+
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 1, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 1 });
 
       const ids0 = page0.body.posts.map((p: IPost) => p.postId);
       const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
@@ -659,7 +674,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should return empty posts when '?page=1000'", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ page: 1000, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ page: 1000 });
 
       expect(res.status).toBe(200);
       expect(res.body.posts).toHaveLength(0);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -238,10 +238,12 @@ describe("POST /api/v1/posts/get", () => {
 
     const page0 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], limit: 2, page: 1, userId: "" });
+      .send({ boardId: [board.boardId], userId: "" })
+      .query({ limit: 2, page: 1 });
     const page1 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], limit: 2, page: 2, userId: "" });
+      .send({ boardId: [board.boardId], userId: "" })
+      .query({ limit: 2, page: 2 });
 
     expect(page0.status).toBe(200);
     expect(page1.status).toBe(200);
@@ -427,7 +429,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should return default first page (no after param)", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], created: "DESC" });
+        .send({ boardId: [board.boardId] })
+        .query({ created: "DESC" });
 
       expect(res.status).toBe(200);
       expect(res.headers["content-type"]).toContain("application/json");

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -64,7 +64,7 @@ describe("POST /api/v1/posts/get", () => {
     // Now request page 2 explicitly to ensure default was page 1
     const resPage2 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ page: 2 });
+      .query({ page: 2 });
     expect(resPage2.headers["content-type"]).toContain("application/json");
     expect(resPage2.status).toBe(200);
 
@@ -309,13 +309,8 @@ describe("POST /api/v1/posts/get", () => {
 
     const asc = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({
-        boardId: [board.boardId],
-        created: "ASC",
-        limit: 10,
-        page: 1,
-        userId: "",
-      });
+      .send({ boardId: [board.boardId], userId: "" })
+      .query({ created: "ASC", limit: 10, page: 1 });
 
     expect(asc.headers["content-type"]).toContain("application/json");
     expect(asc.status).toBe(200);

--- a/packages/theme/src/modules/posts.ts
+++ b/packages/theme/src/modules/posts.ts
@@ -57,7 +57,6 @@ export const getPosts = async ({
   created = "DESC",
   boardId = [],
   roadmapId = undefined,
-  after = undefined,
 }: IFilterPostRequestBody): Promise<AxiosResponse<IFilterPostResponseBody>> => {
   const { authToken } = useUserStore();
 
@@ -70,7 +69,6 @@ export const getPosts = async ({
       created,
       boardId,
       roadmapId,
-      after,
     },
     headers: {
       Authorization: `Bearer ${authToken}`,

--- a/packages/theme/src/modules/posts.ts
+++ b/packages/theme/src/modules/posts.ts
@@ -57,6 +57,7 @@ export const getPosts = async ({
   created = "DESC",
   boardId = [],
   roadmapId = undefined,
+  after = undefined,
 }: IFilterPostRequestBody): Promise<AxiosResponse<IFilterPostResponseBody>> => {
   const { authToken } = useUserStore();
 
@@ -69,6 +70,7 @@ export const getPosts = async ({
       created,
       boardId,
       roadmapId,
+      after,
     },
     headers: {
       Authorization: `Bearer ${authToken}`,

--- a/packages/types/src/posts/post.ts
+++ b/packages/types/src/posts/post.ts
@@ -2,7 +2,12 @@ import type { IPublicUserInfo } from "../user";
 import type { IPostVote } from "../vote";
 import type { IRoadmap } from "../roadmap";
 import type { IBoard } from "../board";
-import type { ApiSortType } from "../common";
+import type {
+  ApiSortType,
+  CursorPaginatedResponse,
+  CursorPaginationParams,
+  IApiStatus,
+} from "../common";
 
 export interface IPost extends IPostInfo {
   board: IBoard | null;
@@ -24,7 +29,7 @@ interface IPostInfo {
   createdAt: Date;
 }
 
-export interface IFilterPostRequestBody {
+export interface IFilterPostRequestBody extends CursorPaginationParams {
   boardId: string[];
   roadmapId?: string;
   page: string;
@@ -32,7 +37,9 @@ export interface IFilterPostRequestBody {
   created: ApiSortType;
 }
 
-export interface IFilterPostResponseBody {
+export interface IFilterPostResponseBody
+  extends Partial<CursorPaginatedResponse<IPost>> {
+  status: IApiStatus;
   posts: IPost[];
 }
 


### PR DESCRIPTION
Fixes #1072 
Integration test are ongoing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor-based pagination with richer metadata (page_info, total_count, total_pages, start/end cursors, has_next_page) and deprecation notice for offset pagination.

* **Client**
  * getPosts accepts an optional after cursor and sends it to the API.

* **Response**
  * Posts include board, roadmap, and voter details; responses consistently include status and results; empty results for out-of-range offset pages.

* **Validation / Error Handling**
  * Stronger request validation with clear 400 errors, including explicit INVALID_CURSOR.

* **Types**
  * Request and response types updated to support cursor pagination and status.

* **Tests**
  * Expanded integration tests covering pagination, validation, sorting, filtering, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->