### PR TITLE
fix(theme): trigger `executeInfiniteScroll` fn when content is not tall enough

### DIFF
--- a/packages/theme/src/components/ui/InfiniteScroll.vue
+++ b/packages/theme/src/components/ui/InfiniteScroll.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed } from "vue";
+import { ref, watch, computed, onMounted } from "vue";
 import { useInfiniteScroll } from "@vueuse/core";
 
 // components
@@ -48,12 +48,18 @@ interface Props {
   state?: InfiniteScrollStateType;
   onInfinite: () => Promise<void> | void;
   canLoadMore?: boolean;
+  /**
+   * Useful when the content is not tall enough to fill up the scrollable container.
+   * @default true
+   */
+  immediateCheck?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   distance: 20,
   state: "LOADING",
   canLoadMore: true,
+  immediateCheck: true,
 });
 
 const isFirstLoad = ref(true);
@@ -83,5 +89,11 @@ useInfiniteScroll(window, executeInfiniteScroll, {
   distance: props.distance,
   direction: "bottom",
   canLoadMore: () => !noMoreResults.value || props.state !== "ERROR",
+});
+
+onMounted(() => {
+  if (props.immediateCheck) {
+    executeInfiniteScroll();
+  }
 });
 </script>


### PR DESCRIPTION
Closes https://github.com/logchimp/logchimp/issues/1325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infinite scroll components now automatically load initial content when mounted. Added configuration option to disable automatic initial loading if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->