### PR TITLE
fix(api/Dockerfile): copy raw email templates in final build stage

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=builder /app/packages/server/package.json ./packages/server/package.
 COPY --from=builder /app/packages/server/dist ./packages/server/dist
 
 # Copy raw email templates
-COPY --from=builder /app/packages/server/src/services/mail/templates ./packages/server/dist/services/mail
+COPY --from=builder /app/packages/server/src/services/mail/templates ./packages/server/dist/services/mail/templates
 
 RUN \
     npm i -g pnpm && \


### PR DESCRIPTION
Closes https://github.com/logchimp/logchimp/issues/1454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Production build updated to include raw email templates in the final runtime image so templates are present and accessible at runtime. This ensures email templates are available after deployment without altering public APIs or exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->