### PR TITLE
fix: Roadmap sort logic and added a integration test for roadmap sort

### DIFF
--- a/packages/server/src/ee/controllers/v1/roadmaps/sort.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/sort.ts
@@ -30,9 +30,9 @@ export async function sort(
     });
   }
 
- if (from.id === to.id) {
-  return res.status(204).send();
-}
+  if (from.id === to.id) {
+    return res.status(204).send();
+  }
 
   try {
     // to

--- a/packages/server/tests/integration/v1/roadmaps.spec.ts
+++ b/packages/server/tests/integration/v1/roadmaps.spec.ts
@@ -886,30 +886,29 @@ describe("PATCH /api/v1/roadmaps/sort", () => {
 
     const r1 = await generateRoadmap({ index: 1 }, true);
     const r2 = await generateRoadmap({ index: 2 }, true);
-const res = await supertest(app)
-  .patch("/api/v1/roadmaps/sort")
-  .set("Authorization", `Bearer ${user.authToken}`)
-  .send({
-    from: { id: r1.id, index: r2.index },
-    to: { id: r2.id, index: r1.index },
-  });
+    const res = await supertest(app)
+      .patch("/api/v1/roadmaps/sort")
+      .set("Authorization", `Bearer ${user.authToken}`)
+      .send({
+        from: { id: r1.id, index: r2.index },
+        to: { id: r2.id, index: r1.index },
+      });
 
-expect(res.status).toBe(200);
+    expect(res.status).toBe(200);
 
-const updatedR1 = await database
-  .select("index")
-  .from("roadmaps")
-  .where({ id: r1.id })
-  .first();
+    const updatedR1 = await database
+      .select("index")
+      .from("roadmaps")
+      .where({ id: r1.id })
+      .first();
 
-const updatedR2 = await database
-  .select("index")
-  .from("roadmaps")
-  .where({ id: r2.id })
-  .first();
+    const updatedR2 = await database
+      .select("index")
+      .from("roadmaps")
+      .where({ id: r2.id })
+      .first();
 
-expect(updatedR1.index).toBe(r2.index);
-expect(updatedR2.index).toBe(r1.index);
-
+    expect(updatedR1.index).toBe(r2.index);
+    expect(updatedR2.index).toBe(r1.index);
   });
 });


### PR DESCRIPTION
This PR fixes a logic issue in the roadmap sorting API where an internal server error occurred if the from and to items were identical.
A guard clause was added to skip redundant database updates when the same item is being “sorted” onto itself.

Prevents unnecessary DB operations and resolves false “Internal Server Error” responses during sort operations.
Fixes #1371 

## Added Integration test for roadmap sort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting efficiency by skipping unnecessary database updates when an item is moved to the same position.

* **Tests**
  * Added comprehensive test coverage for roadmap sorting, including permission validation and reordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->