### PR TITLE
Fix: Roadmap created via SearchRoadmapDropdown not appearing immediately in list (#1422)

### DIFF
--- a/packages/theme/src/ee/components/dashboard/roadmap/SearchRoadmapDropdown/DropdownContent.vue
+++ b/packages/theme/src/ee/components/dashboard/roadmap/SearchRoadmapDropdown/DropdownContent.vue
@@ -1,45 +1,21 @@
 <template>
-  <DropdownMenuContent
-    :class="[
-      'w-(--reka-popper-anchor-width) max-h-60 overflow-y-auto',
-      'shadow-sm border border-neutral-300 bg-white rounded-lg'
-    ]"
-    side="bottom"
-    :loop="true"
-    :side-offset="10"
-    align="start"
-  >
+  <DropdownMenuContent :class="[
+    'w-(--reka-popper-anchor-width) max-h-60 overflow-y-auto',
+    'shadow-sm border border-neutral-300 bg-white rounded-lg'
+  ]" side="bottom" :loop="true" :side-offset="10" align="start">
     <div class="border-b border-neutral-300 sticky top-0 bg-white">
-      <input
-        :id="searchInputId"
-        v-model="search"
-        placeholder="Search roadmaps..."
-        class="px-4 py-3 outline-none grow border-none sm:text-sm w-full"
-        autocomplete="off"
-        autocorrect="off"
-        spellCheck="false"
-        ref="searchInputRef"
-      />
+      <input :id="searchInputId" v-model="search" placeholder="Search roadmaps..."
+        class="px-4 py-3 outline-none grow border-none sm:text-sm w-full" autocomplete="off" autocorrect="off"
+        spellCheck="false" ref="searchInputRef" />
     </div>
 
     <div class="w-full">
-     <NoRoadmap
-       v-if="searchRoadmap.roadmap"
-       @select="selectHandler"
-     />
+      <NoRoadmap v-if="searchRoadmap.roadmap" @select="selectHandler" />
 
-      <ItemSuggestionDropdownItem
-        v-for="item in suggestions"
-        :key="item.id"
-        :suggestion="item"
-        @select="selectHandler"
-      />
+      <ItemSuggestionDropdownItem v-for="item in suggestions" :key="item.id" :suggestion="item"
+        @select="selectHandler" />
 
-      <CreateRoadmapItem
-        v-if="search && suggestions.length === 0"
-        :search="search"
-        @created="selectHandler"
-      />
+      <CreateRoadmapItem v-if="search && suggestions.length === 0" :search="search" @created="selectHandler" />
     </div>
   </DropdownMenuContent>
 </template>
@@ -51,7 +27,7 @@ import { watchDebounced } from "@vueuse/core";
 import type { IRoadmapPrivate } from "@logchimp/types";
 
 import { searchRoadmap as searchRoadmapApi } from "../../../../../modules/roadmaps";
-import { type TCurrentRoadmap, useRoadmapSearch } from "./search";
+import { useRoadmapSearch } from "./search";
 
 import ItemSuggestionDropdownItem from "../../../ItemSuggestionDropdownItem.vue";
 import CreateRoadmapItem from "./CreateRoadmapItem.vue";
@@ -101,9 +77,13 @@ watchDebounced(
   { debounce: 600 },
 );
 
-function selectHandler(e: TCurrentRoadmap) {
+function selectHandler(e: IRoadmapPrivate) {
   if (!e) return;
-  searchRoadmap.select(e);
+  searchRoadmap.select(e); // this just updates current roadmap
+
+  // need to push new roadmap to suggestions for it to appear immediately
+  suggestions.value.push(e)
+
 }
 
 function resetSuggestions() {


### PR DESCRIPTION
Hello @mittalyashu 

I tried to check the /dashboard/posts/PostEditor/Index.vue to search for where the likely issue or where the API is being called, I realised that it imported from /ee/components/dashboard/roadmap/searchroadmapdropdown/dropdown.vue, and this also imported from ./dropdowncontent.vue where i saw the function (selectHandler) that actually handles the searchroadmap selection. I modified the selectHandler function to push the newly created roadmap into the suggestions array after it is selected to ensure that the new roadmap appears immediately in the dropdown without a manual refresh.

`function selectHandler(e: IRoadmapPrivate) {
  if (!e) return;
  searchRoadmap.select(e); // this just updates current roadmap

  // need to push new roadmap to suggestions for it to appear immediately
  suggestions.value.push(e)

}`

I could not fully test the logic on the dashboard UI because of some limitations.

Thank you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Selected roadmaps now appear in dropdown suggestions immediately after selection for enhanced visibility.
  
* **Internal Updates**
  * Updated internal dependencies and type definitions for the roadmap search dropdown component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->