### PR TITLE
auto move cursor to description when title limit exceeded

### DIFF
--- a/packages/theme/src/components/post/CreatePost.vue
+++ b/packages/theme/src/components/post/CreatePost.vue
@@ -11,7 +11,11 @@
       :disabled="createPostPermissionDisabled"
       @keyup-enter="submitPost"
       @hide-error="hideTitleError"
+      @input="handleTitleInput"
     />
+    <HelperText v-if="title.value.length >= 85 && description.length <= 15">
+      After the title limit, you’ll automatically jump to description.
+    </HelperText>
     <l-textarea
       v-model="description"
       label="Description"
@@ -19,6 +23,7 @@
       name="Post description"
       placeholder="What would you use it for?"
       :disabled="createPostPermissionDisabled"
+      ref="descriptionInput"
     />
     <div style="display: flex; justify-content: center;">
       <Button
@@ -47,10 +52,13 @@ import type { FormFieldErrorType } from "../ui/input/formBaseProps";
 import LText from "../ui/input/LText.vue";
 import LTextarea from "../ui/input/LTextarea.vue";
 import Button from "../ui/Button.vue";
+import HelperText from "../ui/input/HelperText.vue";
 
 // utils
 import validateUUID from "../../utils/validateUUID";
 import tokenError from "../../utils/tokenError";
+
+import { MAX_TITLE_LENGTH } from "../../constants";
 
 const { permissions } = useUserStore();
 
@@ -81,6 +89,19 @@ const createPostPermissionDisabled = computed(() => {
   const checkPermission = permissions.includes("post:create");
   return !checkPermission;
 });
+
+const descriptionInput = ref<{ focus: () => void } | null>(null);
+const handleTitleInput = () => {
+  const titleInput = title.value;
+
+  if (titleInput.length >= MAX_TITLE_LENGTH) {
+    const extraText = titleInput.slice(MAX_TITLE_LENGTH);
+    title.value = titleInput.slice(0, MAX_TITLE_LENGTH);
+    description.value += extraText;
+
+    descriptionInput.value?.focus();
+  }
+};
 
 function hideTitleError(event: FormFieldErrorType) {
   title.error = event;

--- a/packages/theme/src/components/ui/input/LTextarea.vue
+++ b/packages/theme/src/components/ui/input/LTextarea.vue
@@ -11,12 +11,14 @@
       :rows="rows"
       :disabled="disabled"
       @input="input"
+      ref="textareaRef"
     />
     <p v-if="error.show" class="input-error-message">{{ error.message }}</p>
   </label>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import { formBaseProps } from "./formBaseProps";
 import { formInputBind } from "./formInputBind";
 
@@ -35,4 +37,11 @@ function input(event: Event) {
   const target = event.target as HTMLTextAreaElement;
   emit("update:modelValue", target.value);
 }
+
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+function focus() {
+  textareaRef.value?.focus();
+}
+
+defineExpose({ focus });
 </script>


### PR DESCRIPTION
Fixes issue: #1475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced post creation with automatic title overflow handling—when the title reaches its maximum length, excess text seamlessly transfers to the description field.
  * Added helper text to guide users about automatic text transfer when title exceeds the character limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->