### PR TITLE
fix(server/auth): handle null responses in email verification and password reset

### DIFF
--- a/packages/server/src/controllers/auth/email/verify.ts
+++ b/packages/server/src/controllers/auth/email/verify.ts
@@ -34,6 +34,13 @@ export async function verify(req: Request, res: Response<ResponseBody>) {
     };
 
     const emailVerification = await verifyEmail(tokenPayload);
+    if (!emailVerification) {
+      res.status(500).send({
+        message: error.general.serverError,
+        code: "SERVER_ERROR",
+      });
+      return;
+    }
 
     /**
      * sending token as response is for

--- a/packages/server/src/controllers/auth/password/reset.ts
+++ b/packages/server/src/controllers/auth/password/reset.ts
@@ -25,7 +25,15 @@ export async function reset(req: Request, res: Response<ResponseBody>) {
       email,
       type: "resetPassword",
     };
+
     const passwordReset = await passwordResetEmail(tokenPayload);
+    if (!passwordReset) {
+      res.status(500).send({
+        message: error.general.serverError,
+        code: "SERVER_ERROR",
+      });
+      return;
+    }
 
     /**
      * sending token as response for


### PR DESCRIPTION
Add explicit checks for `null` or failed operations in email verification and password reset controllers. Send a 500 response with an appropriate error message if these operations fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification now returns proper server error responses when verification fails.
  * Password reset operations are validated to ensure success before returning response, preventing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->