### PR TITLE
fix(theme): prevent duplicate signup submission race on Join page

### DIFF
--- a/packages/theme/src/pages/Join.vue
+++ b/packages/theme/src/pages/Join.vue
@@ -34,8 +34,7 @@
         <Button
           type="primary"
           :loading="buttonLoading"
-          :disabled="!siteSettings.allowSignup"
-          @click="join"
+          :disabled="buttonLoading || !siteSettings.allowSignup"
         >
           Create Account
         </Button>
@@ -100,6 +99,10 @@ function hidePasswordError(event: FormFieldErrorType) {
 }
 
 async function join() {
+  if (buttonLoading.value) {
+    return;
+  }
+
   if (!(email.value && password.value)) {
     if (!email.value) {
       emailError.show = true;


### PR DESCRIPTION
## Summary
Fixes #1571 by preventing duplicate signup submissions from the Join page.

## Root cause
The signup flow could trigger `join()` twice on a single click:
- `<form @submit.prevent="join">` fired on native submit
- `<Button @click="join">` fired explicitly on click

That race can create the account successfully on the first request and then show a `USER_EXISTS` error from the second request.

## Changes
- Removed explicit `@click="join"` on the signup button and relied on form submit.
- Disabled the button while loading: `:disabled="buttonLoading || !siteSettings.allowSignup"`.
- Added an early guard in `join()` to return immediately when `buttonLoading` is already true.

## Testing
- Verified logic by code path inspection: single submit path now, with loading-time re-entry guard.

## AI disclosure (per project policy)
This PR was AI-assisted (OpenClaw/Codex) and fully human-reviewed/edited before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form submission handling to prevent users from accidentally submitting the join form multiple times concurrently, reducing the risk of duplicate submissions and providing a more reliable user experience.
  * Join button now properly respects site-level signup permissions, automatically disabling itself when user registration is not permitted by site administrators or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->