### PR TITLE
fix(activity): show Edited label when comment has been modified

### DIFF
--- a/packages/theme/src/ee/components/activity/ActivityItem.stories.js
+++ b/packages/theme/src/ee/components/activity/ActivityItem.stories.js
@@ -5,7 +5,7 @@ export default {
   component: ActivityItem,
 };
 
-//👇 We create a “template” of how args map to rendering
+//👇 We create a "template" of how args map to rendering
 const Template = (_, { argTypes }) => ({
   components: { ActivityItem },
   props: Object.keys(argTypes),
@@ -23,6 +23,31 @@ Default.args = {
       body: "sda",
       is_internal: false,
       is_edited: false,
+      is_spam: false,
+      created_at: "2021-06-26T06:10:24.536+00:00",
+    },
+    author: {
+      user_id: "5713d443-98b0-4a07-8908-385c4e6afca5",
+      name: "Yashu Mittal",
+      username: "mittalyashu",
+      avatar:
+        "https://www.gravatar.com/avatar/a32d5e3c2f125c7dfc92467707d73f3c",
+    },
+    created_at: "2021-06-26T06:10:24.537Z",
+  },
+};
+
+export const Edited = Template.bind({});
+Edited.args = {
+  activity: {
+    id: "86c4d223-972a-448a-abbe-458eb87fc0c7",
+    type: "comment",
+    comment: {
+      id: "c5e4bddd-6615-4f7a-ae0e-3402ce958df0",
+      parent_id: null,
+      body: "This comment was edited.",
+      is_internal: false,
+      is_edited: true,
       is_spam: false,
       created_at: "2021-06-26T06:10:24.536+00:00",
     },

--- a/packages/theme/src/ee/components/activity/ActivityItem.vue
+++ b/packages/theme/src/ee/components/activity/ActivityItem.vue
@@ -9,13 +9,15 @@
 			<div class="font-medium mb-1">{{ activity.author.name }}</div>
 			<p class="mb-0.5 text-sm break-all">{{ activity.comment.body }}</p>
 
-			<time
-				:datetime="dayjs(activity.created_at).toISOString()"
-				:title="dayjs(activity.created_at).format('dddd, DD MMMM YYYY hh:mm')"
-				class="text-xs text-neutral-600"
-			>
-				{{ dayjs(activity.created_at).fromNow() }}
-			</time>
+			<div class="flex items-center gap-1.5 text-xs text-neutral-600">
+				<time
+					:datetime="dayjs(activity.created_at).toISOString()"
+					:title="dayjs(activity.created_at).format('dddd, DD MMMM YYYY hh:mm')"
+				>
+					{{ dayjs(activity.created_at).fromNow() }}
+				</time>
+				<span v-if="activity.comment.is_edited" class="text-neutral-400">&middot; Edited</span>
+			</div>
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
Fixes #1600

When a comment has been edited, the API already returns `is_edited: true` in the activity response, but the `ActivityItem` component was not displaying any visual indicator of this.

## Changes

- `ActivityItem.vue`: Wraps the timestamp in a flex container and conditionally renders a `· Edited` label next to the time when `activity.comment.is_edited` is `true`.
- `ActivityItem.stories.js`: Adds an `Edited` Storybook story variant to make it easy to visually verify the new behavior.

**Before:** Edited comments looked identical to non-edited ones.

**After:** Edited comments show `· Edited` next to the timestamp in a muted color (`text-neutral-400`).

Signed-off-by: Sputnik-MAC <sputnik.mac.001@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Edited" indicator to activity items, displaying when comments have been modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->