### PR TITLE
Replace `pull_request_target` with `pull_request` in lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check LC_SUBMODULES_TOKEN
+        run: |
+          if [ -z "${{ secrets.LC_SUBMODULES_TOKEN }}" ]; then
+            echo "::error:: You don't have enough permission to run this workflow."
+            exit 1
+          fi
+
       - name: Checkout PR head
         uses: actions/checkout@v6
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now runs on standard pull requests.
  * Automated handling for repository submodules added, with a pre-check to ensure required credentials are provided.
  * Improved workflow feedback by updating how status updates and comments are posted on pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->