### PR TITLE
ci: pass LC_SUBMODULES_TOKEN directory to submodule action instead of making it globally accessible

### DIFF
--- a/.github/workflows/biome-tools.yml
+++ b/.github/workflows/biome-tools.yml
@@ -17,9 +17,6 @@ on:
       - "pnpm-lock.yaml"
   workflow_dispatch:
 
-env:
-  LC_SUBMODULES_TOKEN: ${{ secrets.LC_SUBMODULES_TOKEN }}
-
 jobs:
   formatter:
     name: Formatter
@@ -30,7 +27,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: biomejs/setup-biome@v2
 
@@ -46,7 +43,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: biomejs/setup-biome@v2
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-env:
-  LC_SUBMODULES_TOKEN: ${{ secrets.LC_SUBMODULES_TOKEN }}
-
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -36,7 +33,7 @@ jobs:
 
     - uses: ./.github/actions/submodules
       with:
-        token: ${{ env.LC_SUBMODULES_TOKEN }}
+        token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,6 @@ on:
 env:
   node-version: 22
   pnpm-version: 10
-  LC_SUBMODULES_TOKEN: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
 jobs:
   test:
@@ -30,7 +29,7 @@ jobs:
 
     - uses: ./.github/actions/submodules
       with:
-        token: ${{ env.LC_SUBMODULES_TOKEN }}
+        token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
     - uses: codecarrotlabs/github-actions/.github/actions/node-pnpm@c7e1e7605a3c05a042093219be7020e35b66f494
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ permissions:
 
 env:
   pnpm-version: 10
-  LC_SUBMODULES_TOKEN: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
 jobs:
   theme-unit:
@@ -39,7 +38,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: codecarrotlabs/github-actions/.github/actions/node-pnpm@c7e1e7605a3c05a042093219be7020e35b66f494
         with:
@@ -64,7 +63,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: codecarrotlabs/github-actions/.github/actions/node-pnpm@c7e1e7605a3c05a042093219be7020e35b66f494
         with:
@@ -91,7 +90,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: codecarrotlabs/github-actions/.github/actions/node-pnpm@c7e1e7605a3c05a042093219be7020e35b66f494
         with:
@@ -119,7 +118,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: codecarrotlabs/github-actions/.github/actions/node-pnpm@c7e1e7605a3c05a042093219be7020e35b66f494
         with:
@@ -185,7 +184,7 @@ jobs:
 
       - uses: ./.github/actions/submodules
         with:
-          token: ${{ env.LC_SUBMODULES_TOKEN }}
+          token: ${{ secrets.LC_SUBMODULES_TOKEN }}
 
       - uses: codecarrotlabs/github-actions/.github/actions/node-pnpm@c7e1e7605a3c05a042093219be7020e35b66f494
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use GitHub Secrets for secure token management instead of environment variables, enhancing security practices across automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->