### PR TITLE
feat(ci): create draft release after self-hosted release docker image

### DIFF
--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -175,10 +175,17 @@ jobs:
     steps:
       - name: Create Draft Release
         run: |
-          gh release create $VERSION \
-            --title "$VERSION" \
-            --notes "Release notes here..." \
-            --draft
+          # Check if release already exists
+          if gh release view $VERSION >/dev/null 2>&1; then
+            echo "Release $VERSION already exists"
+            echo "Draft release URL: https://github.com/${{ github.repository }}/releases/tag/$VERSION"
+          else
+            echo "Creating new release $VERSION..."
+            gh release create $VERSION \
+              --title "$VERSION" \
+              --notes "Release notes here..." \
+              --draft
+          fi
         env:
           VERSION: v${{ needs.deploy-target.outputs.latest_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to automatically create and report draft releases after deployment when not a prerelease.
  * Adjusted publishing permissions to the build step to ensure release artifacts can be produced and recorded.
  * Ensures releases use the latest version output from the deploy step and requires a repository token to create drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->