### PR TITLE
fix(roadmap): skip sort API call when drag is canceled or dropped on same spot

### DIFF
--- a/packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue
+++ b/packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue
@@ -51,7 +51,10 @@ import { ref } from "vue";
 import type { ISortRoadmapRequestBody } from "@logchimp/types";
 
 import { useDashboardRoadmaps } from "../../../store/dashboard/roadmaps";
-import type { VueDraggableEvent } from "../../../lib/vuedraggable/types";
+import type {
+  VueDraggableEndEvent,
+  VueDraggableEvent,
+} from "../../../lib/vuedraggable/types";
 import { sortRoadmap } from "../../../modules/roadmaps";
 
 import Table from "../../../../components/ui/Table/Table.vue";
@@ -93,18 +96,22 @@ function moveItem(
   };
 }
 
-async function initialiseSort() {
+async function initialiseSort(event: VueDraggableEndEvent) {
+  drag.value = false;
+
+  // Skip API call when item is dropped at its original position or drag is canceled
+  if (event.oldIndex === event.newIndex) {
+    return;
+  }
+
   try {
     const response = await sortRoadmap(sort.value);
 
     if (response.status === 200) {
-      drag.value = false;
       dashboardRoadmaps.sortRoadmap(sort.value.from.index, sort.value.to.index);
     }
   } catch (err) {
     console.error(err);
-  } finally {
-    drag.value = false;
   }
 }
 

--- a/packages/theme/src/ee/lib/vuedraggable/types.ts
+++ b/packages/theme/src/ee/lib/vuedraggable/types.ts
@@ -13,3 +13,8 @@ export interface VueDraggableEvent<F, T> {
   draggedContext: DraggedContext<T>;
   relatedContext: RelatedContext<F>;
 }
+
+export interface VueDraggableEndEvent {
+  oldIndex: number;
+  newIndex: number;
+}


### PR DESCRIPTION
## Summary

Fixes #1370 (also addresses the frontend part of #1369)

When a roadmap item is dragged and dropped back to its original position — or the drag is simply canceled — vuedraggable fires the `@end` event with identical `oldIndex` and `newIndex` values. Previously `initialiseSort` always triggered a `sortRoadmap` API call regardless of whether the item actually moved.

## Changes

### `packages/theme/src/ee/components/dashboard/roadmap/TabularView.vue`
- `initialiseSort` now receives the vuedraggable end event and returns early when `oldIndex === newIndex`, preventing the unnecessary network request.
- Moved `drag.value = false` to the top of the handler so the drag state is always reset, even on an early return.
- Removed the redundant `drag.value = false` from the `finally` block (no longer needed since it's set unconditionally at the start).

### `packages/theme/src/ee/lib/vuedraggable/types.ts`
- Added `VueDraggableEndEvent` interface (`{ oldIndex: number; newIndex: number }`) to give the end-event parameter a proper type.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Item dragged to a different position | ✅ API call made | ✅ API call made |
| Item dropped on same spot | ❌ Unnecessary API call | ✅ No API call |
| Drag canceled (Escape) | ❌ Unnecessary API call | ✅ No API call |

---

I have read the CLA Document and I hereby sign the CLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved drag-and-drop sorting in the roadmap view to skip redundant operations when items are not repositioned, providing a more responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->