### PR TITLE
feat(sidebar): display LogChimp version at the bottom of Dashboard sidebar

### DIFF
--- a/packages/theme/src/components/dashboard/Sidebar/SidebarContent.vue
+++ b/packages/theme/src/components/dashboard/Sidebar/SidebarContent.vue
@@ -86,6 +86,12 @@
 
     <div class="mt-auto relative">
       <dashboard-sidebar-auth-user-dropdown />
+      <p
+        v-if="logchimpVersion"
+        class="text-center text-xs text-neutral-400 py-1"
+      >
+        v{{ logchimpVersion }}
+      </p>
     </div>
   </div>
 </template>
@@ -104,6 +110,7 @@ import {
 } from "lucide-vue";
 
 import { useSettingStore } from "../../../store/settings";
+import { VITE_LOGCHIMP_VERSION } from "../../../constants";
 
 // components
 import SiteBranding from "../../site/SiteBranding.vue";
@@ -114,4 +121,6 @@ import SidebarListHeading from "./SidebarListHeading.vue";
 import DashboardSidebarAuthUserDropdown from "./AuthUser/Dropdown.vue";
 
 const { get: siteSettings } = useSettingStore();
+
+const logchimpVersion = VITE_LOGCHIMP_VERSION;
 </script>


### PR DESCRIPTION
## Summary

Display the LogChimp version in the Dashboard sidebar footer, below the auth user dropdown. The version is read from the `VITE_LOGCHIMP_VERSION` environment variable (set during the Docker build process or via `.env`). When the variable is not set, the label is hidden.

## Changes

- **`SidebarContent.vue`**: Import `VITE_LOGCHIMP_VERSION` from constants, render a small muted `v{version}` label below the auth-user dropdown when the value is present.

## Before / After

| Before | After |
|--------|-------|
| No version shown | `v0.1.0` shown at the bottom of the sidebar |

## Testing

1. Set `VITE_LOGCHIMP_VERSION=0.1.0` in `packages/theme/.env`
2. Run the theme dev server
3. Open the Dashboard — version appears at the bottom of the left sidebar
4. Without the env variable set, the label does not render

## Type(s) of Change

- [x] New feature (non-breaking change which adds functionality)

Closes #1084

---
I have read the CLA Document and I hereby sign the CLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application version is now displayed in the sidebar for easy reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->