### PR TITLE
feat(dashboard): show confetti after completing onboarding

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -18,6 +18,7 @@
     "@vueuse/core": "10.11.1",
     "@vueuse/head": "1.3.1",
     "axios": "1.13.5",
+    "canvas-confetti": "^1.9.4",
     "dayjs": "1.11.19",
     "lucide-vue": "npm:lucide-vue-next@0.546.0",
     "pinia": "2.3.1",
@@ -30,6 +31,7 @@
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
+    "@types/canvas-confetti": "^1.9.0",
     "@types/uuid": "10.0.0",
     "@vitejs/plugin-vue": "6.0.4",
     "@vue/test-utils": "2.4.6",

--- a/packages/theme/src/pages/dashboard/Index.vue
+++ b/packages/theme/src/pages/dashboard/Index.vue
@@ -107,8 +107,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
 import { useHead } from "@vueuse/head";
+import { useRoute, useRouter } from "vue-router";
+import confetti from "canvas-confetti";
 import type { IBoardPrivate, IPost } from "@logchimp/types";
 
 // modules
@@ -164,6 +166,23 @@ async function getBoards() {
     boardState.value = "ERROR";
   }
 }
+
+const route = useRoute();
+const routerInstance = useRouter();
+
+onMounted(() => {
+  if (route.query.onboarding === "complete") {
+    // Remove the query param so confetti only shows once
+    routerInstance.replace({ query: {} });
+
+    // Fire confetti burst
+    confetti({
+      particleCount: 150,
+      spread: 80,
+      origin: { y: 0.6 },
+    });
+  }
+});
 
 useHead({
   title: "Dashboard",

--- a/packages/theme/src/pages/setup/CreateBoard.vue
+++ b/packages/theme/src/pages/setup/CreateBoard.vue
@@ -33,7 +33,7 @@
     </div>
 
     <AuthFormHelperText>
-      You can <router-link to="/dashboard">skip</router-link> and create one later.
+      You can <router-link to="/dashboard?onboarding=complete">skip</router-link> and create one later.
     </AuthFormHelperText>
   </auth-form>
 </template>
@@ -91,7 +91,7 @@ async function create() {
       display: true,
     });
 
-    router.push("/dashboard");
+    router.push("/dashboard?onboarding=complete");
   } catch (error) {
     console.error(error);
     buttonLoading.value = false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       axios:
         specifier: 1.13.5
         version: 1.13.5
+      canvas-confetti:
+        specifier: ^1.9.4
+        version: 1.9.4
       dayjs:
         specifier: 1.11.19
         version: 1.11.19
@@ -223,6 +226,9 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.5.24(typescript@5.9.3))
     devDependencies:
+      '@types/canvas-confetti':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/uuid':
         specifier: 10.0.0
         version: 10.0.0
@@ -1109,6 +1115,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/canvas-confetti@1.9.0':
+    resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -1493,6 +1502,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  canvas-confetti@1.9.4:
+    resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
 
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
@@ -3886,6 +3898,8 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 24.11.0
 
+  '@types/canvas-confetti@1.9.0': {}
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4348,6 +4362,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  canvas-confetti@1.9.4: {}
 
   chai@5.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

Shows a confetti burst when the site owner lands on the dashboard after completing the onboarding flow (setup → create account → create board / skip).

## Changes

- **`CreateBoard.vue`**: Navigates to `/dashboard?onboarding=complete` (both create + skip paths)
- **`dashboard/Index.vue`**: On mount, checks for the `onboarding=complete` query param, fires `canvas-confetti`, then removes the param via `router.replace` so it only triggers once
- Added `canvas-confetti` dependency (~6 KB gzipped)

## How it works

1. User completes onboarding (creates a board or skips)
2. Router navigates to `/dashboard?onboarding=complete`
3. Dashboard detects the query param on mount → fires confetti → strips the param
4. Refreshing or navigating back won't retrigger the effect

Fixes #1067

---
I have read the CLA Document and I hereby sign the CLA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a celebratory confetti animation that appears when you complete the onboarding flow, providing visual feedback for this important milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->