### PR TITLE
fix(server/roadmap): replace object-based `where` with column-value syntax in roadmap filter

### DIFF
--- a/packages/server/src/ee/controllers/v1/roadmaps/filter.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/filter.ts
@@ -211,8 +211,7 @@ function applyVisibilityFilter<T>(
 ): Knex.QueryBuilder<T> {
   if (!visibility || visibility.length === 0) {
     // Default: show only public roadmaps
-    // @ts-expect-error
-    return query.where({ display: true });
+    return query.where("display", true);
   }
 
   const hasPublic = visibility.includes("public");
@@ -223,17 +222,14 @@ function applyVisibilityFilter<T>(
     return query;
   } else if (hasPublic) {
     // Show only public
-    // @ts-expect-error
-    return query.where({ display: true });
+    return query.where("display", true);
   } else if (hasPrivate) {
     // Show only private
-    // @ts-expect-error
-    return query.where({ display: false });
+    return query.where("display", false);
   }
   // If neither public nor private is specified (edge case), show nothing
   else {
-    // @ts-expect-error
-    return query.where({ display: null });
+    return query.where("display", null);
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Checklist

- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [x] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [x] I have added or updated relevant documentation for the respective change(s) made in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code quality and type safety in roadmap filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->