### PR TITLE
ci: bump Trufflehog version to 3.94.0 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -21,7 +21,7 @@ permissions:
   actions: read
 
 env:
-  TRUFFLEHOG_VERSION: 3.90.8
+  TRUFFLEHOG_VERSION: 3.94.0
 
 jobs:
   trufflehog-cli:


### PR DESCRIPTION
## Summary

Bump Trufflehog version from `v3.90.8` to `v3.94.0`

<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [x] Other (Please mention)

## Checklist

- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [x] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [x] I have added or updated relevant documentation for the respective change(s) made in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal security scanning infrastructure to a newer version, enhancing the scanning capabilities of the development pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->