### PR TITLE
fix(db): clean up migration schema definitions

### DIFF
--- a/packages/server/src/database/migrations/20200906183548_initial_users_table.ts
+++ b/packages/server/src/database/migrations/20200906183548_initial_users_table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("users", (table) => {
-      table.uuid("userId").notNullable().unique().primary();
+      table.uuid("userId").notNullable().primary();
       table.string("name", 30);
       table.string("email", 320).notNullable().unique();
       table.string("password", 72).notNullable();

--- a/packages/server/src/database/migrations/20200906183706_initial_posts_table.ts
+++ b/packages/server/src/database/migrations/20200906183706_initial_posts_table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("posts", (table) => {
-      table.uuid("postId").notNullable().unique().primary();
+      table.uuid("postId").notNullable().primary();
       table.string("title", 100).notNullable();
       table.string("slug", 150).notNullable().unique();
       table.string("slugId", 20).notNullable();

--- a/packages/server/src/database/migrations/20200906184116_initial_votes_table.ts
+++ b/packages/server/src/database/migrations/20200906184116_initial_votes_table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("votes", (table) => {
-      table.uuid("voteId").notNullable().unique().primary();
+      table.uuid("voteId").notNullable().primary();
       table.uuid("userId").references("userId").inTable("users").notNullable();
       table
         .uuid("postId")

--- a/packages/server/src/database/migrations/20200906184214_initial_boards_table.ts
+++ b/packages/server/src/database/migrations/20200906184214_initial_boards_table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("boards", (table) => {
-      table.uuid("boardId").notNullable().unique().primary();
+      table.uuid("boardId").notNullable().primary();
       table.string("name", 50).notNullable();
       table.string("url", 50).notNullable().unique();
       table.string("color", 6).notNullable();

--- a/packages/server/src/database/migrations/20201120175923_seed-settings.ts
+++ b/packages/server/src/database/migrations/20201120175923_seed-settings.ts
@@ -30,6 +30,7 @@ exports.up = (knex) => {
 exports.down = (knex) => {
   return knex("settings")
     .delete()
+    .where({ title: "LogChimp" })
     .then(() => {
       logger.info({
         message: "Drop data: settings",

--- a/packages/server/src/database/migrations/20201125151704_permissions-table.ts
+++ b/packages/server/src/database/migrations/20201125151704_permissions-table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("permissions", (table) => {
-      table.uuid("id").notNullable().unique().primary();
+      table.uuid("id").notNullable().primary();
       table.string("name", 30);
       table.string("type", 20).notNullable();
       table.string("action", 10).notNullable();

--- a/packages/server/src/database/migrations/20201125152807_roles-table.ts
+++ b/packages/server/src/database/migrations/20201125152807_roles-table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("roles", (table) => {
-      table.uuid("id").notNullable().unique().primary();
+      table.uuid("id").notNullable().primary();
       table.string("name", 30).notNullable();
       table.string("description", 50);
       table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());

--- a/packages/server/src/database/migrations/20201125215955_permissions-roles-table.ts
+++ b/packages/server/src/database/migrations/20201125215955_permissions-roles-table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("permissions_roles", (table) => {
-      table.uuid("id").notNullable().unique().primary();
+      table.uuid("id").notNullable().primary();
       table
         .uuid("permission_id")
         .notNullable()

--- a/packages/server/src/database/migrations/20201224104136_add-roadmaps-table.ts
+++ b/packages/server/src/database/migrations/20201224104136_add-roadmaps-table.ts
@@ -4,7 +4,7 @@ import logger from "../../utils/logger";
 exports.up = (knex) => {
   return knex.schema
     .createTable("roadmaps", (table) => {
-      table.uuid("id").notNullable().unique().primary();
+      table.uuid("id").notNullable().primary();
       table.string("name", 50).notNullable();
       table.string("url", 50).notNullable().unique();
       table.integer("index").notNullable();

--- a/packages/server/src/database/migrations/20260326093000_add-permissions-type-action-unique.ts
+++ b/packages/server/src/database/migrations/20260326093000_add-permissions-type-action-unique.ts
@@ -1,0 +1,38 @@
+// utils
+import logger from "../../utils/logger";
+
+exports.up = (knex) => {
+  return knex.schema
+    .alterTable("permissions", (table) => {
+      table.unique(["type", "action"], {
+        indexName: "permissions_type_action_unique",
+      });
+    })
+    .then(() => {
+      logger.info({
+        code: "DATABASE_MIGRATIONS",
+        message:
+          "Added composite unique constraint on permissions(type, action)",
+      });
+    })
+    .catch((err) => {
+      logger.error(err);
+    });
+};
+
+exports.down = (knex) => {
+  return knex.schema
+    .alterTable("permissions", (table) => {
+      table.dropUnique(["type", "action"], "permissions_type_action_unique");
+    })
+    .then(() => {
+      logger.info({
+        code: "DATABASE_MIGRATIONS",
+        message:
+          "Dropped composite unique constraint on permissions(type, action)",
+      });
+    })
+    .catch((err) => {
+      logger.error(err);
+    });
+};


### PR DESCRIPTION
## Summary

This PR addresses three database migration issues:

### 1. Remove redundant `.unique()` on primary key columns (Fixes #1639)

Primary keys are implicitly unique. The `.unique()` call alongside `.primary()` is redundant and adds an unnecessary extra index. Removed from 8 migration files:
- `20200906183548_initial_users_table.ts`
- `20200906183706_initial_posts_table.ts`
- `20200906184116_initial_votes_table.ts`
- `20200906184214_initial_boards_table.ts`
- `20201125151704_permissions-table.ts`
- `20201125152807_roles-table.ts`
- `20201125215955_permissions-roles-table.ts`
- `20201224104136_add-roadmaps-table.ts`

### 2. Fix seed-settings `down()` migration scope (Fixes #1641)

The `down()` migration in `20201120175923_seed-settings.ts` was calling `knex("settings").delete()` without a `WHERE` clause, which would delete **all** rows from the settings table. Fixed to scope deletion to only the seeded row: `.where({ title: "LogChimp" })`.

### 3. Add composite unique constraint on `permissions(type, action)` (Fixes #1638)

Added a new forward migration `20260326093000_add-permissions-type-action-unique.ts` that adds a composite unique constraint on `permissions(type, action)`. The `{ type, action }` pair is used as the natural key throughout the codebase (`database/utils.ts`, `roles/update.ts`), but without this constraint, duplicate logical permissions could be inserted silently.

---

I have read the CLA Document and I hereby sign the CLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database schema structure for improved consistency and reliability.
  * Enhanced data integrity constraints for permissions and access control management.
  * Improved database rollback procedures for settings configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->