### PR TITLE
fix: change update own comment permission to `comment:update:own`

### DIFF
--- a/packages/server/src/ee/controllers/v1/posts/comments/update.ts
+++ b/packages/server/src/ee/controllers/v1/posts/comments/update.ts
@@ -89,7 +89,7 @@ export async function update(
   const requiredPermission = [
     "comment:update:own",
     "comment:update:any",
-  ] as TPermission[];
+  ] satisfies TPermission[];
   const hasPermission = requiredPermission.some((permission) =>
     permissions.includes(permission),
   );


### PR DESCRIPTION
## Summary

A fix which was missed in PR: https://github.com/logchimp/logchimp/pull/1674

<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)

<!-- Link any related issues or tickets. -->

Closes #{ISSUE_NUMBER}

## Changes Made

<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)

<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)

<!-- Describe how you tested your changes. -->

- [ ] Unit tests
- [ ] Integration tests

## Checklist

- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [x] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [x] I have added or updated relevant documentation for the respective change(s) made in this PR.