### PR TITLE
test(authUser): add perms `comment:create` and `comment:update:own` to assert auth user permission

### DIFF
--- a/packages/server/tests/integration/v1/users/authUser.spec.ts
+++ b/packages/server/tests/integration/v1/users/authUser.spec.ts
@@ -256,13 +256,18 @@ describe("[GET] /api/v1/users/permissions", () => {
 
     expect(response.headers["content-type"]).toContain("application/json");
     expect(response.status).toBe(200);
-    expect(response.body.permissions).toEqual([
+
+    const assertedPermsArr = [
       "post:create",
       "vote:create",
       "vote:destroy",
       "comment:create",
       "comment:update:own",
-    ] satisfies TPermission[]);
+    ] satisfies TPermission[];
+
+    expect((response.body.permissions || []).sort()).toEqual(
+      assertedPermsArr.sort(),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Add `comment:create` and `comment:update:own` permission in a integration test for assert the auth user return the intended permissions.

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [x] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [x] Integration tests

## Checklist
- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [x] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [x] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated permission validation tests to expect two additional permissions for the @everyone role: comment creation and comment update.
  * Made permission checks order-insensitive to avoid false failures due to ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->