### PR TITLE
fix(server): remove `roles` property from user object in authentication middleware

### DIFF
--- a/packages/server/src/middlewares/auth/authOptional.ts
+++ b/packages/server/src/middlewares/auth/authOptional.ts
@@ -53,6 +53,8 @@ export async function authOptional(
     logger.error(err);
   }
 
+  delete user.roles;
+
   // @ts-expect-error
   req.user = {
     ...user,

--- a/packages/server/src/middlewares/auth/authOptional.ts
+++ b/packages/server/src/middlewares/auth/authOptional.ts
@@ -10,6 +10,7 @@ import {
 import type {
   IGetUserInfoWithRoles,
   IAuthenticationTokenPayload,
+  IAuthenticationMiddlewareUser,
 } from "../../types";
 import logger from "../../utils/logger";
 import { configManager } from "../../utils/logchimpConfig";
@@ -59,6 +60,6 @@ export async function authOptional(
   req.user = {
     ...user,
     permissions,
-  };
+  } satisfies IAuthenticationMiddlewareUser;
   next();
 }

--- a/packages/server/src/middlewares/auth/authRequired.ts
+++ b/packages/server/src/middlewares/auth/authRequired.ts
@@ -51,6 +51,7 @@ const authenticateWithToken = async (
     }
 
     const permissions = await computePermissions(user);
+    delete user.roles;
 
     // @ts-expect-error
     req.user = {

--- a/packages/server/src/middlewares/auth/authRequired.ts
+++ b/packages/server/src/middlewares/auth/authRequired.ts
@@ -1,7 +1,10 @@
 import type { NextFunction, Request, Response } from "express";
 import type { IApiErrorResponse } from "@logchimp/types";
 
-import type { IAuthenticationTokenPayload } from "../../types";
+import type {
+  IAuthenticationMiddlewareUser,
+  IAuthenticationTokenPayload,
+} from "../../types";
 import error from "../../errorResponse.json";
 import {
   computePermissions,
@@ -57,7 +60,7 @@ const authenticateWithToken = async (
     req.user = {
       ...user,
       permissions,
-    };
+    } satisfies IAuthenticationMiddlewareUser;
     next();
   } catch (err) {
     logger.error(err);

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -15,7 +15,8 @@ export interface IGetUserInfoWithRoles {
   roles: string[];
 }
 
-export interface IAuthenticationMiddlewareUser extends IGetUserInfoWithRoles {
+export interface IAuthenticationMiddlewareUser
+  extends Omit<IGetUserInfoWithRoles, "roles"> {
   permissions: TPermission[];
 }
 


### PR DESCRIPTION
## Summary

<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)

<!-- Link any related issues or tickets. -->

Closes #{ISSUE_NUMBER}

## Changes Made

<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)

<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)

<!-- Describe how you tested your changes. -->

- [ ] Unit tests
- [ ] Integration tests

## Checklist

- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [x] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [x] I have added or updated relevant documentation for the respective change(s) made in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication middleware now excludes `roles` from the user context object and uses `permissions` as the primary authorization mechanism.
  * Enhanced type validation for authenticated user objects across optional and required authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->