### PR TITLE
feat(theme/avatar): add 'bgColor' props to Avatar component for better visibility

### DIFF
--- a/packages/theme/src/components/dashboard/Sidebar/AuthUser/AuthUser.vue
+++ b/packages/theme/src/components/dashboard/Sidebar/AuthUser/AuthUser.vue
@@ -4,6 +4,7 @@
 			<avatar
 				:src="avatar"
 				:name="name || username"
+        bgColor="light"
 			/>
 			<div class="select-none grid grid-cols-1 gap-0.5 text-left">
 				<p class="truncate font-semibold text-neutral-700 text-sm">

--- a/packages/theme/src/components/ui/Avatar/Avatar.vue
+++ b/packages/theme/src/components/ui/Avatar/Avatar.vue
@@ -15,9 +15,9 @@
       data-test="avatar-initials"
       :class="[
         'max-w-8 max-h-8 size-8 rounded-full',
-        'text-(--color-white) font-medium uppercase',
-        'border border-(--color-white)',
+        'border font-medium uppercase',
         'flex items-center justify-center',
+        bgColor === 'dark' ? 'text-(--color-white) border-(--color-white)' : 'text-(--color-black) border-(--color-black)'
       ]"
     >
       {{ name.slice(0, 1) }}
@@ -29,7 +29,10 @@
 interface Props {
   src?: string | null;
   name: string;
+  bgColor?: "light" | "dark";
 }
 
-defineProps<Props>();
+withDefaults(defineProps<Props>(), {
+  bgColor: "dark",
+});
 </script>

--- a/packages/theme/src/ee/components/dashboard/users/TabularItem/TabularItem.vue
+++ b/packages/theme/src/ee/components/dashboard/users/TabularItem/TabularItem.vue
@@ -10,6 +10,7 @@
       <avatar
         :src="user.avatar" :name="user.name || user.username"
         class="shrink-0"
+        bgColor="light"
       />
       <span
         class="text-black line-clamp-1 truncate"


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)

Closes https://github.com/logchimp/logchimp/issues/1514

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Avatar component now adapts styling based on background color mode, applying appropriate text and border colors for optimal contrast on light and dark backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->