### PR TITLE
chore(ci): push image artifacts to GHCR and Docker registry

### DIFF
--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -202,6 +202,7 @@ jobs:
   publish-dockerhub:
     runs-on: ubuntu-latest
     needs: [ deploy-target, build ]
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -65,6 +65,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: deploy-target
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +111,13 @@ jobs:
 
       - name: Install packages
         run: pnpm install --frozen-lockfile
+
+      - name: Login to GitHub Container Registry for cache export
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -202,7 +211,7 @@ jobs:
   publish-dockerhub:
     runs-on: ubuntu-latest
     needs: [ deploy-target, build ]
-    permissions: {}
+    permissions: { }
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -10,6 +10,7 @@ on:
 env:
   node: 22
   pnpm-version: 10
+  REGISTRY_OWNER: logchimp
 
 jobs:
   deploy-target:
@@ -28,19 +29,19 @@ jobs:
         id: deploy-target
         run: |
           GITHUB_REF_NAME="${{ github.ref_name }}"
-          
+
           # Validate that we're running on a version tag
           if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::This workflow must be run on a version tag (e.g., v1.0.0). Current ref: $GITHUB_REF_NAME"
             exit 1
           fi
-          
+
           VERSION="${GITHUB_REF_NAME#v}"  # Remove 'v' prefix
           echo "latest_version=$VERSION" >> $GITHUB_OUTPUT
-          
+
           # Check if this is a prerelease (contains beta, alpha, rc, nightly)
           PRERELEASE="beta|alpha|rc|canary|nightly"
-          
+
           if [[ "$VERSION" =~ ($PRERELEASE) ]]; then
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
             echo "is_latest=false" >> $GITHUB_OUTPUT
@@ -50,7 +51,7 @@ jobs:
             # Get all tags, filter out prereleases, sort by version, get the latest
             LATEST_STABLE=$(git tag -l 'v*' | grep -v -E "($PRERELEASE)" | sort -V | tail -n1)
             LATEST_STABLE="${LATEST_STABLE#v}"
-          
+
             if [ "$VERSION" = "$LATEST_STABLE" ]; then
               echo "is_latest=true" >> $GITHUB_OUTPUT
               echo "This is the latest stable release: $VERSION"
@@ -64,8 +65,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: deploy-target
-    permissions:
-      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -82,14 +81,9 @@ jobs:
           service=${{ matrix.name }}
           SERVICE_NAME=$(basename "${service//-/-}")
           SERVICE_COMMON_NAME=$(echo "$SERVICE_NAME" | sed 's/-ee$//')
-          
+
           echo "SERVICE_NAME=$SERVICE_NAME" >> $GITHUB_ENV
           echo "SERVICE_COMMON_NAME=$SERVICE_COMMON_NAME" >> $GITHUB_ENV
-          echo "REGISTRY_OWNER=logchimp" >> $GITHUB_ENV
-          echo "LATEST_VERSION=${{ needs.deploy-target.outputs.latest_version }}" >> $GITHUB_ENV
-          echo "IS_LATEST=${{ needs.deploy-target.outputs.is_latest }}" >> $GITHUB_ENV
-          echo "IS_PRERELEASE=${{ needs.deploy-target.outputs.is_prerelease }}" >> $GITHUB_ENV
-          echo "This is the service name: $SERVICE_NAME and release version: ${{ needs.deploy-target.outputs.latest_version }}"
 
       - uses: actions/setup-node@v6
         with:
@@ -122,20 +116,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build ${{ env.SERVICE_NAME }} Community Docker Image
         shell: bash
-        env:
-          DOCKER_BUILD_ARGUMENTS: >
-            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/cache:build-cache-${{ env.SERVICE_NAME }}-community
-            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/cache:build-cache-${{ env.SERVICE_NAME }}-community,mode=max
-            --output=type=image,name=ghcr.io/${{ env.REGISTRY_OWNER }}/${{ env.SERVICE_NAME }},push-by-digest=true,name-canonical=true
         run: |
           # change 'api' to 'server'
           SERVICE_COMMON_NAME_LOCAL=$SERVICE_COMMON_NAME
@@ -145,17 +127,69 @@ jobs:
 
           docker buildx build \
             --load -f ./packages/$SERVICE_COMMON_NAME_LOCAL/Dockerfile \
-            --build-arg LOGCHIMP_VERSION=${{ env.LATEST_VERSION }} \
-            -t logchimp-$SERVICE_COMMON_NAME . $DOCKER_BUILD_ARGUMENTS
+            --build-arg LOGCHIMP_VERSION=${{ needs.deploy-target.outputs.latest_version }} \
+            --cache-from type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/cache:build-cache-${{ env.SERVICE_NAME }} \
+            --cache-to type=registry,ref=ghcr.io/${{ env.REGISTRY_OWNER }}/cache:build-cache-${{ env.SERVICE_NAME }},mode=max \
+            -t logchimp-$SERVICE_COMMON_NAME .
           docker images
 
-      - name: Tag and Push docker image
+      - name: Save Docker image as artifact
+        shell: bash
+        run: |
+          docker save logchimp-$SERVICE_COMMON_NAME | gzip > /tmp/logchimp-$SERVICE_COMMON_NAME.tar.gz
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-${{ env.SERVICE_COMMON_NAME }}
+          path: /tmp/logchimp-${{ env.SERVICE_COMMON_NAME }}.tar.gz
+          retention-days: 1
+
+  publish-ghcr:
+    runs-on: ubuntu-latest
+    needs: [ deploy-target, build ]
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ 'logchimp/api', 'logchimp/theme' ]
+
+    steps:
+      - name: Variables
+        run: |
+          service=${{ matrix.name }}
+          SERVICE_NAME=$(basename "${service//-/-}")
+          SERVICE_COMMON_NAME=$(echo "$SERVICE_NAME" | sed 's/-ee$//')
+
+          echo "SERVICE_NAME=$SERVICE_NAME" >> $GITHUB_ENV
+          echo "SERVICE_COMMON_NAME=$SERVICE_COMMON_NAME" >> $GITHUB_ENV
+          echo "IS_LATEST=${{ needs.deploy-target.outputs.is_latest }}" >> $GITHUB_ENV
+          echo "IS_PRERELEASE=${{ needs.deploy-target.outputs.is_prerelease }}" >> $GITHUB_ENV
+
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-image-${{ env.SERVICE_COMMON_NAME }}
+          path: /tmp
+
+      - name: Load Docker image
+        run: docker load < /tmp/logchimp-${{ env.SERVICE_COMMON_NAME }}.tar.gz
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and Push to GitHub Container Registry
         shell: bash
         run: |
           # Always push the version tag
-          docker tag logchimp-$SERVICE_COMMON_NAME ghcr.io/${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ env.LATEST_VERSION }}
-          docker push ghcr.io/${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ env.LATEST_VERSION }}
-          
+          docker tag logchimp-$SERVICE_COMMON_NAME ghcr.io/${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ needs.deploy-target.outputs.latest_version }}
+          docker push ghcr.io/${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ needs.deploy-target.outputs.latest_version }}
+
           # Only tag as 'latest' if this is the latest stable release
           if [ "$IS_LATEST" == "true" ]; then
             echo "Tagging as latest..."
@@ -165,8 +199,59 @@ jobs:
             echo "Skipping 'latest' tag (IS_LATEST=$IS_LATEST, IS_PRERELEASE=$IS_PRERELEASE)"
           fi
 
-  draft-release:
+  publish-dockerhub:
+    runs-on: ubuntu-latest
     needs: [ deploy-target, build ]
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ 'logchimp/api', 'logchimp/theme' ]
+
+    steps:
+      - name: Variables
+        run: |
+          service=${{ matrix.name }}
+          SERVICE_NAME=$(basename "${service//-/-}")
+          SERVICE_COMMON_NAME=$(echo "$SERVICE_NAME" | sed 's/-ee$//')
+
+          echo "SERVICE_NAME=$SERVICE_NAME" >> $GITHUB_ENV
+          echo "SERVICE_COMMON_NAME=$SERVICE_COMMON_NAME" >> $GITHUB_ENV
+          echo "IS_LATEST=${{ needs.deploy-target.outputs.is_latest }}" >> $GITHUB_ENV
+          echo "IS_PRERELEASE=${{ needs.deploy-target.outputs.is_prerelease }}" >> $GITHUB_ENV
+
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-image-${{ env.SERVICE_COMMON_NAME }}
+          path: /tmp
+
+      - name: Load Docker image
+        run: docker load < /tmp/logchimp-${{ env.SERVICE_COMMON_NAME }}.tar.gz
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.LOGCHIMP_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.LOGCHIMP_DOCKERHUB_TOKEN }}
+
+      - name: Tag and Push to Docker Hub
+        shell: bash
+        run: |
+          # Always push the version tag
+          docker tag logchimp-$SERVICE_COMMON_NAME ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ needs.deploy-target.outputs.latest_version }}
+          docker push ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ needs.deploy-target.outputs.latest_version }}
+
+          # Only tag as 'latest' if this is the latest stable release
+          if [ "$IS_LATEST" == "true" ]; then
+            echo "Tagging as latest..."
+            docker tag logchimp-$SERVICE_COMMON_NAME ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:latest
+            docker push ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:latest
+          else
+            echo "Skipping 'latest' tag (IS_LATEST=$IS_LATEST, IS_PRERELEASE=$IS_PRERELEASE)"
+          fi
+
+  draft-release:
+    needs: [ deploy-target, publish-ghcr, publish-dockerhub ]
     runs-on: ubuntu-latest
     if: ${{ needs.deploy-target.outputs.is_prerelease == 'false' }}
     permissions:

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -248,14 +248,14 @@ jobs:
         shell: bash
         run: |
           # Always push the version tag
-          docker tag logchimp-$SERVICE_COMMON_NAME ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ needs.deploy-target.outputs.latest_version }}
-          docker push ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:${{ needs.deploy-target.outputs.latest_version }}
+          docker tag logchimp-$SERVICE_COMMON_NAME ${{ env.REGISTRY_OWNER }}/${{ env.REGISTRY_OWNER }}-${{ env.SERVICE_NAME }}:${{ needs.deploy-target.outputs.latest_version }}
+          docker push ${{ env.REGISTRY_OWNER }}/${{ env.REGISTRY_OWNER }}-${{ env.SERVICE_NAME }}:${{ needs.deploy-target.outputs.latest_version }}
 
           # Only tag as 'latest' if this is the latest stable release
           if [ "$IS_LATEST" == "true" ]; then
             echo "Tagging as latest..."
-            docker tag logchimp-$SERVICE_COMMON_NAME ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:latest
-            docker push ${{ env.REGISTRY_OWNER }}/${{ matrix.name }}:latest
+            docker tag logchimp-$SERVICE_COMMON_NAME ${{ env.REGISTRY_OWNER }}/${{ env.REGISTRY_OWNER }}-${{ env.SERVICE_NAME }}:latest
+            docker push ${{ env.REGISTRY_OWNER }}/${{ env.REGISTRY_OWNER }}-${{ env.SERVICE_NAME }}:latest
           else
             echo "Skipping 'latest' tag (IS_LATEST=$IS_LATEST, IS_PRERELEASE=$IS_PRERELEASE)"
           fi

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -148,7 +148,7 @@ jobs:
           docker save logchimp-$SERVICE_COMMON_NAME | gzip > /tmp/logchimp-$SERVICE_COMMON_NAME.tar.gz
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: docker-image-${{ env.SERVICE_COMMON_NAME }}
           path: /tmp/logchimp-${{ env.SERVICE_COMMON_NAME }}.tar.gz
@@ -177,7 +177,7 @@ jobs:
           echo "IS_PRERELEASE=${{ needs.deploy-target.outputs.is_prerelease }}" >> $GITHUB_ENV
 
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: docker-image-${{ env.SERVICE_COMMON_NAME }}
           path: /tmp
@@ -230,7 +230,7 @@ jobs:
           echo "IS_PRERELEASE=${{ needs.deploy-target.outputs.is_prerelease }}" >> $GITHUB_ENV
 
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: docker-image-${{ env.SERVICE_COMMON_NAME }}
           path: /tmp


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)

Closes https://github.com/logchimp/logchimp/issues/1662

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Separated image build and publish into distinct workflow steps for more reliable CI.
  * Builds now produce and upload image artifacts; publish jobs download, load, tag, and push to GHCR and Docker Hub.
  * Added a workflow-level registry owner setting.
  * Release drafting now waits for both publishing jobs to finish.
  * Build step now reads version info directly from the deploy step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->