### PR TITLE
Feat/keep dropdown open on pressing shift key

### DIFF
--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
@@ -59,6 +59,21 @@ describe("DropdownV2CheckboxItem", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("should prevent dropdown close on pointer selection when [keepOpenOnShift=true, shift=pressed]", async () => {
+    const wrapper = shallowMount(CheckboxItem, {
+      props: {
+        keepOpenOnShift: true,
+      },
+    });
+
+    await wrapper.trigger("pointerdown", { shiftKey: true });
+    await wrapper.trigger("pointerup", { shiftKey: true });
+    const event = createCancelableSelectEvent();
+    triggerSelectOnStub(wrapper, event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("should use latest pointer modifier state at selection time", async () => {
     const wrapper = shallowMount(CheckboxItem, {
       props: {

--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
@@ -17,7 +17,7 @@ function triggerSelectOnStub(
 }
 
 describe("DropdownV2CheckboxItem", () => {
-  it("prevents dropdown close when keepOpenOnShift is enabled and shift is held (keyboard)", async () => {
+  it("should prevent dropdown close [keepOpenOnShift=true, shift=pressed]", async () => {
     const wrapper = shallowMount(CheckboxItem, {
       props: {
         keepOpenOnShift: true,
@@ -31,7 +31,7 @@ describe("DropdownV2CheckboxItem", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
-  it("does not prevent dropdown close when keepOpenOnShift is disabled", async () => {
+  it("should not prevent dropdown close [keepOpenOnShift=false, shift=pressed]", async () => {
     const wrapper = shallowMount(CheckboxItem, {
       props: {
         keepOpenOnShift: false,
@@ -45,7 +45,21 @@ describe("DropdownV2CheckboxItem", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
-  it("uses latest pointer modifier state at selection time", async () => {
+  it("should prevent dropdown close on Enter key selection when [keepOpenOnShift=true, shift=pressed]", async () => {
+    const wrapper = shallowMount(CheckboxItem, {
+      props: {
+        keepOpenOnShift: true,
+      },
+    });
+
+    await wrapper.trigger("keydown", { key: "Enter", shiftKey: true });
+    const event = createCancelableSelectEvent();
+    triggerSelectOnStub(wrapper, event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("should use latest pointer modifier state at selection time", async () => {
     const wrapper = shallowMount(CheckboxItem, {
       props: {
         keepOpenOnShift: true,

--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { DropdownMenuCheckboxItem } from "reka-ui";
 import { shallowMount } from "@vue/test-utils";
 
 import CheckboxItem from "./CheckboxItem.vue";
 
 function createCancelableSelectEvent() {
   return new Event("select", { cancelable: true });
+}
+
+function triggerSelectOnStub(
+  wrapper: ReturnType<typeof shallowMount>,
+  event: Event,
+) {
+  const stub = wrapper.findComponent(DropdownMenuCheckboxItem);
+  stub.vm.$emit("select", event);
 }
 
 describe("DropdownV2CheckboxItem", () => {
@@ -17,7 +26,7 @@ describe("DropdownV2CheckboxItem", () => {
 
     await wrapper.trigger("keydown", { shiftKey: true });
     const event = createCancelableSelectEvent();
-    wrapper.element.dispatchEvent(event);
+    triggerSelectOnStub(wrapper, event);
 
     expect(event.defaultPrevented).toBe(true);
   });
@@ -31,7 +40,7 @@ describe("DropdownV2CheckboxItem", () => {
 
     await wrapper.trigger("keydown", { shiftKey: true });
     const event = createCancelableSelectEvent();
-    wrapper.element.dispatchEvent(event);
+    triggerSelectOnStub(wrapper, event);
 
     expect(event.defaultPrevented).toBe(false);
   });
@@ -46,7 +55,7 @@ describe("DropdownV2CheckboxItem", () => {
     await wrapper.trigger("pointerdown", { shiftKey: true });
     await wrapper.trigger("pointerup", { shiftKey: false });
     const event = createCancelableSelectEvent();
-    wrapper.element.dispatchEvent(event);
+    triggerSelectOnStub(wrapper, event);
 
     expect(event.defaultPrevented).toBe(false);
   });

--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+
+import CheckboxItem from "./CheckboxItem.vue";
+
+function createCancelableSelectEvent() {
+  return new Event("select", { cancelable: true });
+}
+
+describe("DropdownV2CheckboxItem", () => {
+  it("prevents dropdown close when keepOpenOnShift is enabled and shift is held (keyboard)", async () => {
+    const wrapper = shallowMount(CheckboxItem, {
+      props: {
+        keepOpenOnShift: true,
+      },
+    });
+
+    await wrapper.trigger("keydown", { shiftKey: true });
+    const event = createCancelableSelectEvent();
+    wrapper.element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not prevent dropdown close when keepOpenOnShift is disabled", async () => {
+    const wrapper = shallowMount(CheckboxItem, {
+      props: {
+        keepOpenOnShift: false,
+      },
+    });
+
+    await wrapper.trigger("keydown", { shiftKey: true });
+    const event = createCancelableSelectEvent();
+    wrapper.element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("uses latest pointer modifier state at selection time", async () => {
+    const wrapper = shallowMount(CheckboxItem, {
+      props: {
+        keepOpenOnShift: true,
+      },
+    });
+
+    await wrapper.trigger("pointerdown", { shiftKey: true });
+    await wrapper.trigger("pointerup", { shiftKey: false });
+    const event = createCancelableSelectEvent();
+    wrapper.element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.vue
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.vue
@@ -36,7 +36,6 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
 import {
   DropdownMenuCheckboxItem,
   DropdownMenuItemIndicator,
@@ -56,30 +55,30 @@ const props = withDefaults(defineProps<Props>(), {
 
 defineEmits<(e: "update:modelValue", event: boolean) => void>();
 
-const shiftPressed = ref(false);
+let shiftPressed = false;
 
 function onPointerDown(event: PointerEvent) {
-  shiftPressed.value = event.shiftKey;
+  shiftPressed = event.shiftKey;
 }
 
 function onPointerUp(event: PointerEvent) {
-  shiftPressed.value = event.shiftKey;
+  shiftPressed = event.shiftKey;
 }
 
 function onPointerCancel(event: PointerEvent) {
-  shiftPressed.value = event.shiftKey;
+  shiftPressed = event.shiftKey;
 }
 
 function onKeyDown(event: KeyboardEvent) {
-  shiftPressed.value = event.shiftKey;
+  shiftPressed = event.shiftKey;
 }
 
 function onKeyUp(event: KeyboardEvent) {
-  shiftPressed.value = event.shiftKey;
+  shiftPressed = event.shiftKey;
 }
 
 function onSelect(event: Event) {
-  if (props.keepOpenOnShift && shiftPressed.value) {
+  if (props.keepOpenOnShift && shiftPressed) {
     event.preventDefault();
   }
 }

--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.vue
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.vue
@@ -3,6 +3,8 @@
     :modelValue="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
     @pointerdown="onPointerDown"
+    @pointerup="onPointerUp"
+    @pointercancel="onPointerCancel"
     @keydown="onKeyDown"
     @keyup="onKeyUp"
     @select="onSelect"
@@ -57,6 +59,14 @@ defineEmits<(e: "update:modelValue", event: boolean) => void>();
 const shiftPressed = ref(false);
 
 function onPointerDown(event: PointerEvent) {
+  shiftPressed.value = event.shiftKey;
+}
+
+function onPointerUp(event: PointerEvent) {
+  shiftPressed.value = event.shiftKey;
+}
+
+function onPointerCancel(event: PointerEvent) {
   shiftPressed.value = event.shiftKey;
 }
 

--- a/packages/theme/src/components/ui/DropdownV2/CheckboxItem.vue
+++ b/packages/theme/src/components/ui/DropdownV2/CheckboxItem.vue
@@ -2,6 +2,10 @@
   <DropdownMenuCheckboxItem
     :modelValue="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
+    @pointerdown="onPointerDown"
+    @keydown="onKeyDown"
+    @keyup="onKeyUp"
+    @select="onSelect"
     :disabled="disabled"
     :class="[
       // styled copied from DropdownV2Item.vue
@@ -30,6 +34,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import {
   DropdownMenuCheckboxItem,
   DropdownMenuItemIndicator,
@@ -37,12 +42,37 @@ import {
 } from "reka-ui";
 import { CheckIcon } from "lucide-vue";
 
-withDefaults(defineProps<DropdownMenuCheckboxItemProps>(), {
+interface Props extends DropdownMenuCheckboxItemProps {
+  keepOpenOnShift?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
   modelValue: false,
   disabled: false,
+  keepOpenOnShift: false,
 });
 
 defineEmits<(e: "update:modelValue", event: boolean) => void>();
+
+const shiftPressed = ref(false);
+
+function onPointerDown(event: PointerEvent) {
+  shiftPressed.value = event.shiftKey;
+}
+
+function onKeyDown(event: KeyboardEvent) {
+  shiftPressed.value = event.shiftKey;
+}
+
+function onKeyUp(event: KeyboardEvent) {
+  shiftPressed.value = event.shiftKey;
+}
+
+function onSelect(event: Event) {
+  if (props.keepOpenOnShift && shiftPressed.value) {
+    event.preventDefault();
+  }
+}
 
 defineOptions({
   name: "DropdownV2CheckboxItem",

--- a/packages/theme/src/ee/components/dashboard/users/TabularItem/AssignRoleUserDropdownContent.vue
+++ b/packages/theme/src/ee/components/dashboard/users/TabularItem/AssignRoleUserDropdownContent.vue
@@ -8,6 +8,7 @@
       v-for="role in dashboardRoles.roles"
       :model-value="userHasRole(role.id)"
       @update:model-value="(checked) => updateRoleHandler(role.id, checked)"
+      :keep-open-on-shift="true"
       :key="role.id"
     >
       <span>


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)

Closes https://github.com/logchimp/logchimp/issues/1283

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [x] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [x] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdown checkbox items can remain open when toggling selections while holding Shift, enabling faster bulk role changes.

* **Tests**
  * Added test coverage validating Shift-key behavior across keyboard and pointer interactions to ensure selections and dropdown open/close behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->