### PR TITLE
fix(ee): enforce comment:delete:own ownership in comment destroy handler

### DIFF
--- a/packages/server/src/ee/controllers/v1/posts/comments/destroy.ts
+++ b/packages/server/src/ee/controllers/v1/posts/comments/destroy.ts
@@ -43,8 +43,17 @@ export async function destroy(
   }
 
   // @ts-expect-error
+  const userId = req.user?.userId as string | undefined;
+
+  // @ts-expect-error
   const permissions = (req.user?.permissions || []) as TPermission[];
-  const hasPermission = permissions.includes("comment:delete:any");
+  const requiredPermission = [
+    "comment:delete:own",
+    "comment:delete:any",
+  ] satisfies TPermission[];
+  const hasPermission = requiredPermission.some((permission) =>
+    permissions.includes(permission),
+  );
   if (!hasPermission) {
     res.status(403).send({
       message: error.api.roles.notEnoughPermission,
@@ -65,6 +74,43 @@ export async function destroy(
       code: "NOT_ENOUGH_PERMISSION",
     });
     return;
+  }
+
+  const ownComment = permissions.includes(
+    "comment:delete:own" satisfies TPermission,
+  );
+  if (ownComment && !permissions.includes("comment:delete:any")) {
+    let isAuthor: { id: string } | undefined;
+    try {
+      isAuthor = await database
+        .select<{ id: string }>("id")
+        .from("posts_activity")
+        .where({
+          type: "comment",
+          posts_comments_id: comment_id,
+          author_id: userId,
+        })
+        .first();
+    } catch (err) {
+      logger.error({
+        level: "error",
+        message: "failed to check if user is author of comment",
+        err,
+      });
+      res.status(500).send({
+        message: error.general.serverError,
+        code: "SERVER_ERROR",
+      });
+      return;
+    }
+
+    if (!isAuthor?.id) {
+      res.status(403).send({
+        message: error.api.comments.notAnAuthor,
+        code: "UNAUTHORIZED_NOT_AUTHOR",
+      });
+      return;
+    }
   }
 
   try {


### PR DESCRIPTION
Related to #1582

While looking at the authorization findings in #1582, I noticed most are already handled on `master`:

- **Comment `update` IDOR** — already fixed: `update.ts` now requires `comment:update:own`/`:any` and verifies authorship via `posts_activity`.
- **Unauthenticated post activity** — appears intentional: the route uses `authOptional` and internal comments are filtered server-side by `postCommentVisibility()`, with a test covering the unauthenticated case. Left untouched — that's your call.

The one place still inconsistent is **`destroy.ts`**.

## Problem

`destroy.ts` only checks `comment:delete:any`. The `comment:delete:own` permission (which exists in the type system, the migration, and the role seeder) is **inert** — a user granted `:own` is rejected with 403, and there is no ownership-enforced delete path at all. `update.ts` already has this; `destroy.ts` was never brought in line.

## Fix

Mirror the exact pattern from `update.ts`:

- Accept `comment:delete:own` **or** `comment:delete:any`.
- When the user has `:own` (and not `:any`), verify they authored the comment via `posts_activity` (`{ type: "comment", posts_comments_id, author_id }`) before deleting; otherwise `403 UNAUTHORIZED_NOT_AUTHOR`.
- `:any` holders keep deleting any comment (unchanged).

Same `satisfies TPermission[]`, same ownership query, same error code as `update.ts` — no new conventions introduced. Fails closed if `userId` is absent.

## Verified

- TypeScript: 0 new errors (the pre-existing `licenseGuard` errors are identical on `master`).
- Biome: clean.
- Logic walked through all three permission cases (`:any`, `:own`-author, `:own`-not-author, none).

---

Came across LogChimp and noticed #1582 had been open a while, so I dug into it and tightened the one spot still inconsistent. No strings attached — I'm with Choreless and we like contributing real fixes to projects we use. If it's useful and you ever want a hand with something larger, happy to help.

— Charles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment deletion authorization with granular permission controls. Users with specific permission scopes can now delete their own comments instead of requiring broader administrative permissions. Enhanced validation and error handling provide appropriate feedback for authorization failures, improving system access control and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->