### PR TITLE
fix: get updated site settings after completing onboarding

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,6 +49,11 @@ jobs:
         # Theme
         LOGCHIMP_API_URL: ${{ env.API_URL }}
 
+    - name: log migrator container
+      if: always()
+      run: |
+        docker compose -f ./docker/local/docker-compose.ci.yml logs migrator
+
     - name: Wait for frontend
       run: npx wait-on http://localhost:3000
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,11 +49,6 @@ jobs:
         # Theme
         LOGCHIMP_API_URL: ${{ env.API_URL }}
 
-    - name: log migrator container
-      if: always()
-      run: |
-        docker compose -f ./docker/local/docker-compose.ci.yml logs migrator
-
     - name: Wait for frontend
       run: npx wait-on http://localhost:3000
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pnpm-store
 .DS_Store
 node_modules
 

--- a/docker/local/docker-compose.ci.yml
+++ b/docker/local/docker-compose.ci.yml
@@ -30,9 +30,7 @@ services:
       context: ../..
       args:
         DOCKER_BUILDKIT: 1
-    working_dir: /app/packages/server
-    entrypoint: ""
-    command: sh -c "pnpm knex --knexfile ./dist/database/config.js migrate:latest && echo ' Migration done'"
+    command: [ "sh", "./scripts/migrate.sh"]
     depends_on:
       db:
         condition: service_healthy

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
 COPY --from=builder /app/packages/server/package.json ./packages/server/package.json
 COPY --from=builder /app/packages/server/dist ./packages/server/dist

--- a/packages/server/src/controllers/auth/setup.ts
+++ b/packages/server/src/controllers/auth/setup.ts
@@ -7,6 +7,8 @@ import type {
 
 // database
 import database from "../../database";
+import * as cache from "../../cache";
+import { CACHE_KEYS } from "../../cache/keys";
 
 // services
 import { createUser } from "../../services/auth/createUser";
@@ -23,7 +25,8 @@ export async function setup(
   res: Response<ResponseBody>,
   next: NextFunction,
 ) {
-  const { siteTitle, name, email, password } = req.body;
+  const { name, email, password } = req.body;
+  let siteTitle = (req.body?.siteTitle || "").trim();
 
   if (!validEmail(email)) {
     return res.status(400).send({
@@ -74,11 +77,21 @@ export async function setup(
         userId: user.userId,
       });
 
-    await database
-      .update({
-        title: siteTitle,
-      })
-      .from("settings");
+    if (siteTitle) {
+      await database
+        .update({
+          title: siteTitle,
+        })
+        .from("settings");
+
+      if (cache.isActive) {
+        try {
+          await cache.valkey.del(CACHE_KEYS.SITE_SETTINGS);
+        } catch (err) {
+          logger.error({ message: err });
+        }
+      }
+    }
 
     res.status(201).send({ user });
   } catch (err) {

--- a/packages/server/src/controllers/auth/setup.ts
+++ b/packages/server/src/controllers/auth/setup.ts
@@ -26,7 +26,7 @@ export async function setup(
   next: NextFunction,
 ) {
   const { name, email, password } = req.body;
-  let siteTitle = (req.body?.siteTitle || "").trim();
+  const siteTitle = String(req.body?.siteTitle || "").trim();
 
   if (!validEmail(email)) {
     return res.status(400).send({

--- a/packages/theme/src/App.vue
+++ b/packages/theme/src/App.vue
@@ -15,14 +15,13 @@
 
 <script setup lang="ts">
 // packages
-import axios, { type AxiosError } from "axios";
+import type { AxiosError } from "axios";
 import { computed, onMounted, watch } from "vue";
 import type { IApiErrorResponse } from "@logchimp/types";
 // import gtag, { setOptions, bootstrap } from "vue-gtag";
 import { useHead } from "@vueuse/head";
 
 import packageJson from "../package.json";
-import { VITE_API_URL } from "./constants";
 
 import { useSettingStore } from "./store/settings";
 import { useUserStore } from "./store/user";
@@ -38,19 +37,6 @@ const { getAlerts, remove: removeAlert } = useAlertStore();
 const userStore = useUserStore();
 
 const logchimpVersion = computed(() => packageJson.version);
-
-function getSiteSettings() {
-  axios({
-    method: "get",
-    url: `${VITE_API_URL}/api/v1/settings/site`,
-  })
-    .then((response) => {
-      settingsStore.updateSettings(response.data.settings);
-    })
-    .catch((error) => {
-      console.error(error);
-    });
-}
 
 watch(
   () => settingsStore.get.accentColor,
@@ -68,7 +54,7 @@ watch(
 );
 
 onMounted(async () => {
-  getSiteSettings();
+  settingsStore.getSiteSettings();
 
   // set google analytics
   if (settingsStore.get.googleAnalyticsId) {

--- a/packages/theme/src/App.vue
+++ b/packages/theme/src/App.vue
@@ -54,7 +54,7 @@ watch(
 );
 
 onMounted(async () => {
-  settingsStore.getSiteSettings();
+  await settingsStore.getSiteSettings();
 
   // set google analytics
   if (settingsStore.get.googleAnalyticsId) {

--- a/packages/theme/src/pages/dashboard/Index.vue
+++ b/packages/theme/src/pages/dashboard/Index.vue
@@ -115,6 +115,7 @@ import type { IBoardPrivate, IPost } from "@logchimp/types";
 // modules
 import { getPosts } from "../../modules/posts";
 import { getAllBoards } from "../../ee/modules/boards";
+import { useSettingStore } from "../../store/settings";
 
 // components
 import InfiniteScroll, {
@@ -130,6 +131,7 @@ const posts = ref<IPost[]>([]);
 const postState = ref<InfiniteScrollStateType>();
 const boards = ref<IBoardPrivate[]>([]);
 const boardState = ref<InfiniteScrollStateType>();
+const settingsStore = useSettingStore();
 
 async function getRecentPosts() {
   postState.value = "LOADING";
@@ -174,6 +176,8 @@ onMounted(() => {
     // Remove the query param so confetti only shows once
     const { onboarding, ...restQuery } = route.query;
     routerInstance.replace({ query: restQuery });
+
+    settingsStore.getSiteSettings();
 
     import("canvas-confetti")
       .then((confetti) => {

--- a/packages/theme/src/store/settings.ts
+++ b/packages/theme/src/store/settings.ts
@@ -1,6 +1,8 @@
 import { computed, reactive } from "vue";
 import { defineStore } from "pinia";
 import type { ISiteSettings } from "@logchimp/types";
+import axios from "axios";
+import { VITE_API_URL } from "../constants";
 
 export const useSettingStore = defineStore("settings", () => {
   const settings = reactive<ISiteSettings>({
@@ -24,6 +26,19 @@ export const useSettingStore = defineStore("settings", () => {
   const get = computed(() => settings);
   const labs = computed(() => settings.labs);
 
+  function getSiteSettings() {
+    axios({
+      method: "get",
+      url: `${VITE_API_URL}/api/v1/settings/site`,
+    })
+      .then((response) => {
+        updateSettings(response.data.settings);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
   function updateSettings(payload: ISiteSettings) {
     Object.assign(settings, payload);
   }
@@ -45,6 +60,7 @@ export const useSettingStore = defineStore("settings", () => {
     labs,
 
     // actions
+    getSiteSettings,
     updateSettings,
     updateLabs,
     updateLogo,

--- a/packages/theme/src/store/settings.ts
+++ b/packages/theme/src/store/settings.ts
@@ -26,17 +26,16 @@ export const useSettingStore = defineStore("settings", () => {
   const get = computed(() => settings);
   const labs = computed(() => settings.labs);
 
-  function getSiteSettings() {
-    axios({
-      method: "get",
-      url: `${VITE_API_URL}/api/v1/settings/site`,
-    })
-      .then((response) => {
-        updateSettings(response.data.settings);
-      })
-      .catch((error) => {
-        console.error(error);
+  async function getSiteSettings() {
+    try {
+      const response = await axios({
+        method: "get",
+        url: `${VITE_API_URL}/api/v1/settings/site`,
       });
+      updateSettings(response.data.settings);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   function updateSettings(payload: ISiteSettings) {


### PR DESCRIPTION
## Summary

Setting the site name during the onboarding process did not **immediately** reflected in the dashboard.

Including `pnpm-workspace.yaml` file in final stage of production environment server Dockerfile.

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site title updates now ignore blank or whitespace-only values.
  * Site settings refresh automatically when the application loads and after onboarding is completed.
  * Updated settings are reflected consistently throughout the application.

* **Bug Fixes**
  * Improved resilience when site-settings requests or cache updates fail.

* **Chores**
  * Improved local migration and application container setup.
  * Added package manager files to the application build and excluded local package-store files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->