### PR TITLE
fix: sanitise post on create and update

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,7 +32,8 @@
     "uuid": "^12.0.1",
     "valibot": "^1.2.0",
     "validator": "^13.15.35",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.3.0",

--- a/packages/server/src/controllers/post/create.ts
+++ b/packages/server/src/controllers/post/create.ts
@@ -34,7 +34,8 @@ export async function create(
 
   const rawTitle = String(req.body.title || "").trim();
   let title = xss(rawTitle) || "new post";
-  let contentMarkdown = xss(String(req.body.contentMarkdown || "").trim());
+  let contentMarkdown =
+    xss(String(req.body.contentMarkdown || "").trim()) || null;
   const boardId = validUUID(req.body.boardId);
 
   if (title.length > POST_TITLE_MAX_LENGTH) {

--- a/packages/server/src/controllers/post/create.ts
+++ b/packages/server/src/controllers/post/create.ts
@@ -7,12 +7,13 @@ import type {
   ICreatePostResponseBody,
   TPermission,
 } from "@logchimp/types";
+import xss from "xss";
 import { POST_TITLE_MAX_LENGTH } from "../../constants";
 
 import database from "../../database";
 
 // utils
-import { validUUID, generateNanoID as nanoid } from "../../helpers";
+import { generateNanoID as nanoid, validUUID } from "../../helpers";
 import logger from "../../utils/logger";
 
 import error from "../../errorResponse.json";
@@ -31,8 +32,9 @@ export async function create(
   // @ts-expect-error
   const permissions = req.user.permissions as TPermission[];
 
-  let title = req.body.title || "new post";
-  let contentMarkdown = req.body.contentMarkdown || "";
+  const rawTitle = String(req.body.title || "").trim();
+  let title = xss(rawTitle) || "new post";
+  let contentMarkdown = xss(String(req.body.contentMarkdown || "").trim());
   const boardId = validUUID(req.body.boardId);
 
   if (title.length > POST_TITLE_MAX_LENGTH) {

--- a/packages/server/src/controllers/post/updatePost.ts
+++ b/packages/server/src/controllers/post/updatePost.ts
@@ -6,6 +6,7 @@ import type {
   TUpdatePostResponseBody,
 } from "@logchimp/types";
 import * as v from "valibot";
+import xss from "xss";
 import database from "../../database";
 
 // utils
@@ -66,7 +67,11 @@ export async function updatePost(
   const id = validUUID(req.body.id);
   const boardId = validUUID(req.body.boardId);
   const roadmapId = validUUID(req.body.roadmapId);
-  const { title, contentMarkdown } = body.output;
+
+  const { title: rawTitle, contentMarkdown: rawContentMarkdown } = body.output;
+  const title = xss((String(rawTitle) || "").trim());
+  const contentMarkdown =
+    xss((String(rawContentMarkdown) || "").trim()) || null;
 
   const slug = `${title
     .replace(/[^\w\s]/gi, "")

--- a/packages/server/src/controllers/post/updatePost.ts
+++ b/packages/server/src/controllers/post/updatePost.ts
@@ -70,8 +70,7 @@ export async function updatePost(
 
   const { title: rawTitle, contentMarkdown: rawContentMarkdown } = body.output;
   const title = xss((String(rawTitle) || "").trim());
-  const contentMarkdown =
-    xss((String(rawContentMarkdown) || "").trim()) || null;
+  const contentMarkdown = xss(String(rawContentMarkdown || "").trim()) || null;
 
   const slug = `${title
     .replace(/[^\w\s]/gi, "")

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import supertest from "supertest";
 import { faker } from "@faker-js/faker";
 import { v4 as uuid } from "uuid";
+import xss from "xss";
 import type { IBoard, IPost, IUpdatePostRequestBody } from "@logchimp/types";
 
 import app from "../../../src/app";
@@ -15,6 +16,55 @@ import {
   vote as assignVote,
 } from "../../utils/generators";
 import { createRoleWithPermissions } from "../../utils/createRoleWithPermissions";
+
+/**
+ * Malicious/HTML-injection payloads used to verify that the post `title` and
+ * `contentMarkdown` are sanitised via `xss()` before being persisted.
+ *
+ * Every one of these stays <= POST_TITLE_MAX_LENGTH once sanitised, so they can
+ * be used for the `title` field without triggering the truncation logic.
+ */
+const htmlPayloads = [
+  // Script tags
+  `<script>alert('XSS')</script>`,
+  `"><script>alert('XSS')</script>`,
+  `'><img src=x onerror=alert('XSS')>`,
+  `<!--<script>alert('XSS')</script>-->`,
+
+  // Event handler attributes
+  `<img src=x onerror=alert('XSS')>`,
+  `<svg onload=alert('XSS')>`,
+  `<body onload=alert('XSS')>`,
+  `<input onfocus=alert('XSS') autofocus>`,
+  `<marquee onstart=alert('XSS')>x</marquee>`,
+  `<details open ontoggle=alert('XSS')>`,
+  `<video><source onerror=alert('XSS')>`,
+
+  // javascript: protocol in attributes
+  `<a href="javascript:alert('XSS')">click</a>`,
+  `<iframe src="javascript:alert('XSS')"></iframe>`,
+  `<object data="javascript:alert('XSS')"></object>`,
+  `<embed src="javascript:alert('XSS')">`,
+  `<form action="javascript:alert('XSS')"><input type=submit>`,
+  `<table background="javascript:alert('XSS')">`,
+
+  // CSS based injection
+  `<div style="background:url(javascript:alert('XSS'))">x</div>`,
+  `<style>@import 'javascript:alert(1)';</style>`,
+
+  // Bare javascript: string (kept as plain text, but must never execute)
+  `javascript:alert('XSS')`,
+];
+
+/**
+ * Longer polyglot payloads that have no upper bound issue for `contentMarkdown`
+ * (which is not length limited).
+ */
+const contentPayloads = [
+  ...htmlPayloads,
+  `javascript:/*--></title></style></textarea></script></xmp><svg/onload='+/"/+/onmouseover=1/+/[*/[]/+alert(1)//'>`,
+  `'"--></style></script><script>alert(String.fromCharCode(88,83,83))</script>`,
+];
 
 // Get posts with filters
 describe("POST /api/v1/posts/get", () => {
@@ -569,6 +619,52 @@ describe("POST /api/v1/posts", () => {
       `...${chunks[1]}\n\n${contentMarkdown}`,
     );
   });
+
+  htmlPayloads.map((payload, index) =>
+    it(`should sanitise post title #${index + 1}: '${payload}'`, async () => {
+      const { user: authUser } = await createUser({ isVerified: true });
+
+      const response = await supertest(app)
+        .post("/api/v1/posts")
+        .set("Authorization", `Bearer ${authUser.authToken}`)
+        .send({
+          title: payload,
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(201);
+
+      const post = response.body.post as IPost;
+      // controller runs: xss(rawTitle) || "new post"
+      expect(post.title).toBe(xss(payload.trim()) || "new post");
+      // sanitised output must never contain an executable script tag
+      expect(post.title).not.toMatch(/<script/i);
+      // slug is derived from the sanitised title, so it must stay clean too
+      expect(post.slug).not.toMatch(/<|>/);
+    }),
+  );
+
+  contentPayloads.map((payload, index) =>
+    it(`should sanitise post content #${index + 1}: '${payload.substring(0, 60)}${payload.length > 60 ? "..." : ""}'`, async () => {
+      const { user: authUser } = await createUser({ isVerified: true });
+
+      const response = await supertest(app)
+        .post("/api/v1/posts")
+        .set("Authorization", `Bearer ${authUser.authToken}`)
+        .send({
+          title: "Safe title",
+          contentMarkdown: payload,
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(201);
+
+      const post = response.body.post as IPost;
+      expect(post.title).toBe("Safe title");
+      expect(post.contentMarkdown).toBe(xss(payload.trim()));
+      expect(post.contentMarkdown).not.toMatch(/<script/i);
+    }),
+  );
 });
 
 describe("PATCH /api/v1/posts", () => {
@@ -804,6 +900,74 @@ describe("PATCH /api/v1/posts", () => {
     const slugSuffix = oldSlug.split("-").slice(-1)[0];
     expect(updated.slug.endsWith(`-${slugSuffix}`)).toBe(true);
   });
+
+  htmlPayloads.map((payload, index) =>
+    it(`should sanitise post title #${index + 1}: '${payload}'`, async () => {
+      const board = await generateBoard({}, true);
+      const roadmap = await generateRoadmap({}, true);
+      const { user: author } = await createUser({ isVerified: true });
+      const post = await generatePost(
+        {
+          userId: author.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+
+      const response = await supertest(app)
+        .patch("/api/v1/posts")
+        .set("Authorization", `Bearer ${author.authToken}`)
+        .send({
+          id: post.postId,
+          title: payload,
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const updated = response.body.post as IPost;
+      expect(updated.title).toBe(xss(payload.trim()));
+      expect(updated.title).not.toMatch(/<script/i);
+      expect(updated.slug).not.toMatch(/<|>/);
+    }),
+  );
+
+  contentPayloads.map((payload, index) =>
+    it(`should sanitise post content #${index + 1}: '${payload.substring(0, 60)}${payload.length > 60 ? "..." : ""}'`, async () => {
+      const board = await generateBoard({}, true);
+      const roadmap = await generateRoadmap({}, true);
+      const { user: author } = await createUser({ isVerified: true });
+      const post = await generatePost(
+        {
+          userId: author.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+
+      const response = await supertest(app)
+        .patch("/api/v1/posts")
+        .set("Authorization", `Bearer ${author.authToken}`)
+        .send({
+          id: post.postId,
+          title: "Safe title",
+          contentMarkdown: payload,
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const updated = response.body.post as IPost;
+      expect(updated.title).toBe("Safe title");
+      // controller runs: xss(rawContentMarkdown) || null
+      expect(updated.contentMarkdown).toBe(xss(payload.trim()) || null);
+      if (updated.contentMarkdown) {
+        expect(updated.contentMarkdown).not.toMatch(/<script/i);
+      }
+    }),
+  );
 });
 
 describe("DELETE /api/v1/posts", () => {

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import supertest from "supertest";
 import { faker } from "@faker-js/faker";
 import { v4 as uuid } from "uuid";
@@ -8,11 +8,10 @@ import type { IBoard, IPost, IUpdatePostRequestBody } from "@logchimp/types";
 import app from "../../../src/app";
 import * as cache from "../../../src/cache";
 import { createUser } from "../../utils/seed/user";
-import { updateSettings } from "../../utils/seed/settings";
 import {
   board as generateBoard,
-  roadmap as generateRoadmap,
   post as generatePost,
+  roadmap as generateRoadmap,
   vote as assignVote,
 } from "../../utils/generators";
 import { createRoleWithPermissions } from "../../utils/createRoleWithPermissions";
@@ -661,8 +660,10 @@ describe("POST /api/v1/posts", () => {
 
       const post = response.body.post as IPost;
       expect(post.title).toBe("Safe title");
-      expect(post.contentMarkdown).toBe(xss(payload.trim()));
-      expect(post.contentMarkdown).not.toMatch(/<script/i);
+      expect(post.contentMarkdown).toBe(xss(payload.trim()) || null);
+      if (post.contentMarkdown) {
+        expect(post.contentMarkdown).not.toMatch(/<script/i);
+      }
     }),
   );
 });

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -20,6 +20,7 @@
     "axios": "1.16.0",
     "canvas-confetti": "^1.9.4",
     "dayjs": "1.11.21",
+    "dompurify": "^3.4.11",
     "lucide-vue": "npm:lucide-vue-next@0.546.0",
     "pinia": "2.3.1",
     "reka-ui": "^2.10.1",

--- a/packages/theme/src/pages/posts/_slug/Index.vue
+++ b/packages/theme/src/pages/posts/_slug/Index.vue
@@ -56,6 +56,7 @@ import { useHead } from "@vueuse/head";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import type { IPost, IPostVote } from "@logchimp/types";
+import DOMPurify from "dompurify";
 
 // modules
 import { router } from "../../../router";
@@ -136,9 +137,8 @@ async function postBySlug() {
       isPostExist.value = true;
 
       if (response.data.post?.contentMarkdown) {
-        postContent.value = response.data.post.contentMarkdown.replace(
-          /\n/g,
-          "<br>",
+        postContent.value = DOMPurify.sanitize(
+          response.data.post.contentMarkdown.replace(/\n/g, "<br>"),
         );
       }
     } catch (error: unknown) {

--- a/packages/theme/src/router.ts
+++ b/packages/theme/src/router.ts
@@ -38,7 +38,7 @@ const routes = [
       },
       {
         path: "posts/:slug",
-        name: "Posts view",
+        name: "PostPublicViewer",
         component: () => import("./pages/posts/_slug/Index.vue"),
       },
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       dayjs:
         specifier: 1.11.21
         version: 1.11.21
+      dompurify:
+        specifier: ^3.4.11
+        version: 3.4.11
       lucide-vue:
         specifier: npm:lucide-vue-next@0.546.0
         version: lucide-vue-next@0.546.0(vue@3.5.34(typescript@5.9.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       winston:
         specifier: ^3.3.3
         version: 3.18.3
+      xss:
+        specifier: ^1.0.15
+        version: 1.0.15
     devDependencies:
       '@faker-js/faker':
         specifier: ^10.3.0
@@ -1667,6 +1670,9 @@ packages:
 
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  cssfilter@0.0.10:
+    resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
 
   cssom@0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -3332,6 +3338,11 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xss@1.0.15:
+    resolution: {integrity: sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==}
+    engines: {node: '>= 0.10.0'}
+    hasBin: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -4480,6 +4491,8 @@ snapshots:
       which: 2.0.2
 
   crypt@0.0.2: {}
+
+  cssfilter@0.0.10: {}
 
   cssom@0.3.8: {}
 
@@ -6157,6 +6170,11 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xss@1.0.15:
+    dependencies:
+      commander: 2.20.3
+      cssfilter: 0.0.10
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

Sanitise post on create and update operation in API and sanitise `post.contentMarkdown` on PostPublicViewer page in the DOM.

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Sanitizes post titles and Markdown content on create/update to strip unsafe HTML.
  - Sanitizes Markdown content when rendering public post pages to help prevent script execution.
- **Bug Fixes**
  - Stores whitespace-only or fully-sanitized Markdown content as `null`.
  - Ensures generated slugs avoid unsafe angle-bracket characters.
- **Refactor**
  - Renamed the public post route identifier (no URL change).
- **Tests**
  - Added coverage for sanitization and `null`/default handling across create and update endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->