### PR TITLE
trx emails/05 send password reset email via worker

### DIFF
--- a/packages/server/src/controllers/auth/password/reset.ts
+++ b/packages/server/src/controllers/auth/password/reset.ts
@@ -16,6 +16,7 @@ import type { IPasswordResetJwtPayload } from "../../../types";
 import { getUserByEmail } from "../../../repository/user";
 import database from "../../../database";
 import { mailQueue } from "../../../worker/tasks/mail";
+import { mailWorker } from "../../../worker/handler/mail";
 
 type ResponseBody = IAuthPasswordResetResponseBody | IApiErrorResponse;
 
@@ -46,15 +47,11 @@ export async function reset(req: Request, res: Response<ResponseBody>) {
       type: "resetPassword",
     };
 
-    await mailQueue.sendPasswordResetTokenMail(tokenPayload);
-    // const passwordReset = await sendPasswordResetTokenMail(tokenPayload);
-    // if (!passwordReset) {
-    //   res.status(500).send({
-    //     message: error.general.serverError,
-    //     code: "SERVER_ERROR",
-    //   });
-    //   return;
-    // }
+    if (mailWorker.isRunning) {
+      await mailQueue.sendPasswordResetTokenMail(tokenPayload);
+    } else {
+      await sendPasswordResetTokenMail(tokenPayload);
+    }
 
     res.status(200).send({
       reset: {

--- a/packages/server/src/controllers/auth/password/reset.ts
+++ b/packages/server/src/controllers/auth/password/reset.ts
@@ -6,15 +6,16 @@ import type {
 } from "@logchimp/types";
 
 // services
-import { passwordReset as passwordResetEmail } from "../../../services/auth/passwordReset";
+import { sendPasswordResetTokenMail } from "../../../services/mail/mail.service";
 
 // utils
 import logger from "../../../utils/logger";
 import error from "../../../errorResponse.json";
-import { isDevTestEnv, validEmail } from "../../../helpers";
+import { validEmail } from "../../../helpers";
 import type { IPasswordResetJwtPayload } from "../../../types";
 import { getUserByEmail } from "../../../repository/user";
 import database from "../../../database";
+import { mailQueue } from "../../../worker/tasks/mail";
 
 type ResponseBody = IAuthPasswordResetResponseBody | IApiErrorResponse;
 
@@ -45,29 +46,19 @@ export async function reset(req: Request, res: Response<ResponseBody>) {
       type: "resetPassword",
     };
 
-    const passwordReset = await passwordResetEmail(tokenPayload);
-    if (!passwordReset) {
-      res.status(500).send({
-        message: error.general.serverError,
-        code: "SERVER_ERROR",
-      });
-      return;
-    }
-
-    /**
-     * sending token as response for
-     * development/testing/staging environment
-     */
-    const __token = isDevTestEnv
-      ? {
-          ...passwordReset,
-        }
-      : undefined;
+    await mailQueue.sendPasswordResetTokenMail(tokenPayload);
+    // const passwordReset = await sendPasswordResetTokenMail(tokenPayload);
+    // if (!passwordReset) {
+    //   res.status(500).send({
+    //     message: error.general.serverError,
+    //     code: "SERVER_ERROR",
+    //   });
+    //   return;
+    // }
 
     res.status(200).send({
       reset: {
-        success: Boolean(passwordReset.createdAt),
-        __token,
+        success: true,
       },
     });
   } catch (err) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import app from "./app";
 import { ready as routesReady } from "./routes/v1";
 
 import { createWorkerClient } from "./worker/client";
+import { mailQueue } from "./worker/tasks/mail";
 import { mailWorker } from "./worker/handler/mail";
 
 // utils
@@ -21,6 +22,7 @@ const host = config.serverHost || "0.0.0.0";
 
   // Run background worker
   const connection = await createWorkerClient();
+  mailQueue.init(connection);
   await mailWorker.run(connection);
 
   app.listen(port, host, async () => {

--- a/packages/server/src/services/mail/mail.service.ts
+++ b/packages/server/src/services/mail/mail.service.ts
@@ -1,20 +1,18 @@
 import type { TResetPassword } from "@logchimp/types";
 
-import database from "../../database";
-
-// services
-import { mail, generateContent } from "../mail";
-import { createToken } from "../token.service";
-
-// utils
-import { configManager } from "../../utils/logchimpConfig";
-import logger from "../../utils/logger";
 import type { IPasswordResetJwtPayload } from "../../types";
-import type { EmailPasswordReset } from "../mail/types";
+import { createToken } from "../token.service";
+import database from "../../database";
+import { generateContent } from "./generateContent";
+import type { EmailPasswordReset } from "./types";
+import { mail } from "./mail";
+import { configManager } from "../../utils/logchimpConfig";
 
 const config = configManager.getConfig();
 
-export async function passwordReset(tokenPayload: IPasswordResetJwtPayload) {
+export async function sendPasswordResetTokenMail(
+  tokenPayload: IPasswordResetJwtPayload,
+) {
   const token = createToken(tokenPayload, {
     expiresIn: "2h",
   });
@@ -87,6 +85,6 @@ export async function passwordReset(tokenPayload: IPasswordResetJwtPayload) {
 
     return insertPasswordResetToken[0];
   } catch (err) {
-    logger.error(err);
+    throw new Error(err);
   }
 }

--- a/packages/server/src/services/mail/mail.service.ts
+++ b/packages/server/src/services/mail/mail.service.ts
@@ -17,74 +17,70 @@ export async function sendPasswordResetTokenMail(
     expiresIn: "2h",
   });
 
-  try {
-    // remove existing resetPassword request
-    await database.delete().from("resetPassword").where({
+  // remove existing resetPassword request
+  await database.delete().from("resetPassword").where({
+    email: tokenPayload.email,
+  });
+
+  const insertPasswordResetToken = await database<TResetPassword>(
+    "resetPassword",
+  )
+    .insert({
       email: tokenPayload.email,
-    });
+      token,
+    })
+    .returning("*");
 
-    const insertPasswordResetToken = await database<TResetPassword>(
-      "resetPassword",
-    )
-      .insert({
-        email: tokenPayload.email,
-        token,
-      })
-      .returning("*");
+  /**
+   * Get site title for using it in email footer
+   */
+  const siteInfo = await database
+    .select<
+      Array<{
+        title: string;
+        accentColor: string;
+        logo: string;
+      }>
+    >("title", "accentColor", "logo")
+    .from("settings");
 
-    /**
-     * Get site title for using it in email footer
-     */
-    const siteInfo = await database
-      .select<
-        Array<{
-          title: string;
-          accentColor: string;
-          logo: string;
-        }>
-      >("title", "accentColor", "logo")
-      .from("settings");
-
-    if (siteInfo.length === 0) {
-      throw new Error("Site settings not found");
-    }
-
-    const siteTitle = siteInfo[0].title;
-    let brandColor = siteInfo[0].accentColor;
-    const siteLogo =
-      siteInfo[0].logo ||
-      "https://cdn.logchimp.codecarrot.net/logchimp_circular_logo.png";
-
-    if (brandColor && !brandColor.startsWith("#")) {
-      brandColor = `#${brandColor}`;
-    }
-
-    const urlObject = new URL(config.webUrl);
-    const passwordResetMailContent = await generateContent<EmailPasswordReset>(
-      "auth/email-password-reset",
-      {
-        recipientEmail: tokenPayload.email,
-        url: urlObject.origin,
-        domain: urlObject.host,
-        resetLink: `${urlObject.origin}/password-reset/confirm/?token=${token}`,
-        siteTitle,
-        brandColor,
-        siteLogo,
-      },
-    );
-
-    const noReplyEmail = `noreply@${urlObject.hostname}`;
-
-    await mail.sendMail({
-      from: noReplyEmail,
-      to: tokenPayload.email,
-      subject: `${siteTitle} - Reset your account password`,
-      text: passwordResetMailContent.text,
-      html: passwordResetMailContent.html,
-    });
-
-    return insertPasswordResetToken[0];
-  } catch (err) {
-    throw new Error(err);
+  if (siteInfo.length === 0) {
+    throw new Error("Site settings not found");
   }
+
+  const siteTitle = siteInfo[0].title;
+  let brandColor = siteInfo[0].accentColor;
+  const siteLogo =
+    siteInfo[0].logo ||
+    "https://cdn.logchimp.codecarrot.net/logchimp_circular_logo.png";
+
+  if (brandColor && !brandColor.startsWith("#")) {
+    brandColor = `#${brandColor}`;
+  }
+
+  const urlObject = new URL(config.webUrl);
+  const passwordResetMailContent = await generateContent<EmailPasswordReset>(
+    "auth/email-password-reset",
+    {
+      recipientEmail: tokenPayload.email,
+      url: urlObject.origin,
+      domain: urlObject.host,
+      resetLink: `${urlObject.origin}/password-reset/confirm/?token=${token}`,
+      siteTitle,
+      brandColor,
+      siteLogo,
+    },
+  );
+
+  const noReplyEmail = `noreply@${urlObject.hostname}`;
+
+  await mail.sendMail({
+    from: noReplyEmail,
+    to: tokenPayload.email,
+    subject: `${siteTitle} - Reset your account password`,
+    text: passwordResetMailContent.text,
+    html: passwordResetMailContent.html,
+  });
+
+  return insertPasswordResetToken[0];
 }

--- a/packages/server/src/worker/handler/mail.ts
+++ b/packages/server/src/worker/handler/mail.ts
@@ -4,6 +4,8 @@ import logger from "../../utils/logger";
 import { mailQueueName } from "../tasks/mail";
 import * as mailService from "../../services/mail/mail.service";
 
+type MailJobHandler = (data: unknown) => Promise<unknown>;
+
 class MailWorker {
   private workerInstance: Worker;
 
@@ -47,17 +49,22 @@ class MailWorker {
     });
   }
 
+  private getHandlers(): Record<string, MailJobHandler> {
+    return Object.assign(Object.create(null), mailService);
+  }
+
   private async handler(job: Job) {
     const name = job.name;
     const data = job.data;
 
-    if (name in mailService) {
-      await mailService[name](data);
-    } else {
-      await job.moveToFailed(Error(`job name '${name}' not found`), job.token);
+    const handlers = this.getHandlers();
+    const handler = handlers[name];
+
+    if (!handler) {
+      throw new Error(`Unsupported mail job name: '${job.name}'`);
     }
 
-    return null;
+    await handler(data);
   }
 
   private sendMail() {}

--- a/packages/server/src/worker/handler/mail.ts
+++ b/packages/server/src/worker/handler/mail.ts
@@ -8,6 +8,7 @@ class MailWorker {
   private workerInstance: Worker;
 
   private readonly workerName: string;
+  isRunning: boolean = false;
 
   constructor(name: string) {
     this.workerName = name;
@@ -30,10 +31,19 @@ class MailWorker {
 
     this.workerInstance.run().catch((err) => {
       logger.error("Worker stopped unexpectedly:", err);
+      this.isRunning = true;
+    });
+
+    this.workerInstance.on("ready", () => {
+      this.isRunning = true;
     });
 
     this.workerInstance.on("error", (err) => {
       logger.error("Mail worker error:", err);
+    });
+
+    this.workerInstance.on("closed", () => {
+      this.isRunning = false;
     });
   }
 

--- a/packages/server/src/worker/handler/mail.ts
+++ b/packages/server/src/worker/handler/mail.ts
@@ -1,6 +1,9 @@
 import { type ConnectionOptions, type Job, Worker } from "bullmq";
 import logger from "../../utils/logger";
 
+import { mailQueueName } from "../tasks/mail";
+import * as mailService from "../../services/mail/mail.service";
+
 class MailWorker {
   private workerInstance: Worker;
 
@@ -34,9 +37,20 @@ class MailWorker {
     });
   }
 
-  handler(job: Job) {
+  private async handler(job: Job) {
+    const name = job.name;
+    const data = job.data;
+
+    if (name in mailService) {
+      await mailService[name](data);
+    } else {
+      await job.moveToFailed(Error(`job name '${name}' not found`), job.token);
+    }
+
     return null;
   }
+
+  private sendMail() {}
 }
 
-export const mailWorker = new MailWorker("mail");
+export const mailWorker = new MailWorker(mailQueueName);

--- a/packages/server/src/worker/handler/mail.ts
+++ b/packages/server/src/worker/handler/mail.ts
@@ -31,7 +31,7 @@ class MailWorker {
 
     this.workerInstance.run().catch((err) => {
       logger.error("Worker stopped unexpectedly:", err);
-      this.isRunning = true;
+      this.isRunning = false;
     });
 
     this.workerInstance.on("ready", () => {

--- a/packages/server/src/worker/tasks/mail.ts
+++ b/packages/server/src/worker/tasks/mail.ts
@@ -1,0 +1,40 @@
+import { type ConnectionOptions, Queue, type QueueOptions } from "bullmq";
+
+import type { IPasswordResetJwtPayload } from "../../types";
+
+type BaseQueueOptions = Omit<QueueOptions, "connection">;
+
+export const mailQueueName = "trx-mails";
+class MailQueue {
+  private queueInstance: Queue;
+
+  private readonly queueName: string;
+  private readonly queueOptions: BaseQueueOptions;
+
+  constructor(queueName: string, options?: BaseQueueOptions) {
+    this.queueName = queueName;
+    this.queueOptions = options;
+  }
+
+  public init(connection: ConnectionOptions) {
+    if (this.queueInstance || !connection) {
+      return;
+    }
+
+    this.queueInstance = new Queue(this.queueName, {
+      ...this.queueOptions,
+      connection: connection as ConnectionOptions,
+    });
+  }
+
+  sendPasswordResetTokenMail(payload: IPasswordResetJwtPayload) {
+    return this.queueInstance.add("sendPasswordResetTokenMail", payload);
+  }
+}
+
+export const mailQueue = new MailQueue(mailQueueName, {
+  defaultJobOptions: {
+    attempts: 1,
+    removeOnComplete: true,
+  },
+});

--- a/packages/server/tests/integration/v1/auth/password.spec.ts
+++ b/packages/server/tests/integration/v1/auth/password.spec.ts
@@ -6,6 +6,7 @@ import app from "../../../../src/app";
 import { createToken } from "../../../../src/services/token.service";
 import { createUser } from "../../../utils/seed/user";
 import database from "../../../../src/database";
+import type { IAuthPasswordResetResponseBody } from "@logchimp/types";
 
 async function resetPassword() {
   const { user } = await createUser();
@@ -54,8 +55,9 @@ describe("POST /api/v1/auth/password/reset", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers["content-type"]).toContain("application/json");
-    expect(response.body).toHaveProperty("reset.__token.token");
-    expect(typeof response.body.reset.__token.token).toBe("string");
+    const body = response.body satisfies IAuthPasswordResetResponseBody;
+    expect(body).toHaveProperty("reset.success");
+    expect(typeof body.reset.success).toBeTruthy();
   });
 });
 

--- a/packages/server/tests/integration/v1/auth/password.spec.ts
+++ b/packages/server/tests/integration/v1/auth/password.spec.ts
@@ -57,7 +57,7 @@ describe("POST /api/v1/auth/password/reset", () => {
     expect(response.headers["content-type"]).toContain("application/json");
     const body = response.body satisfies IAuthPasswordResetResponseBody;
     expect(body).toHaveProperty("reset.success");
-    expect(typeof body.reset.success).toBeTruthy();
+    expect(body.reset.success).toBe(true);
   });
 });
 

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -45,7 +45,6 @@ export interface IAuthPasswordResetRequestBody {
 export interface IAuthPasswordResetResponseBody {
   reset: {
     success: boolean;
-    __token?: TResetPassword;
   };
 }
 


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset emails are now processed reliably in the background, with direct delivery available when needed.
  * Reset emails now include current site branding.
  * Email processing reports its availability and handles password reset messages asynchronously.

* **Bug Fixes**
  * Password reset responses no longer expose development tokens.
  * Failed email processing now recovers readiness and surfaces errors.
  * Successful password reset requests now consistently return a success response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->