### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ This helps us align efforts and prevents duplicated or conflicting work.
 
 ## Stargazers over time
 
-[![Star History Chart](https://api.star-history.com/svg?repos=logchimp/logchimp&type=timeline&legend=top-left)](https://www.star-history.com/#logchimp/logchimp&type=timeline&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=logchimp/logchimp&type=timeline&legend=top-left)](https://star-history.dera.page/#logchimp/logchimp&type=timeline&legend=top-left)


### PR DESCRIPTION
The Star History chart currently embedded in the README no longer renders because of GitHub stargazer API restrictions. This is a required fix: it updates both the chart image and the link so the stargazers graph works again and the project's growth remains visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Stargazers over time” chart to use the new Star History service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->