### PR TITLE
trx emails/08: option to notify about roadmap change or not

### DIFF
--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -1,7 +1,6 @@
 import type { Request, Response } from "express";
 import type {
   IApiErrorResponse,
-  IRoadmapPrivate,
   IUpdatePostRequestBody,
   TPermission,
   TUpdatePostResponseBody,
@@ -25,6 +24,13 @@ const bodySchema = v.object({
     "POST_TITLE_MISSING",
   ),
   contentMarkdown: v.optional(v.nullable(v.pipe(v.string(), v.trim()))),
+  boardId: v.optional(v.nullable(v.string())),
+  roadmapId: v.optional(v.nullable(v.string())),
+  roadmap: v.optional(
+    v.object({
+      notifyVoters: v.boolean(),
+    }),
+  ),
 });
 
 const schemaBodyErrorMap = {
@@ -105,7 +111,10 @@ export async function updatePost(
       })
       .returning("*");
 
-    if (currentRoadmapId !== newRoadmapId) {
+    if (
+      body.output.roadmap?.notifyVoters &&
+      currentRoadmapId !== newRoadmapId
+    ) {
       try {
         await postsQueue.postRoadmapChangeEvent({
           postId: id,

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -112,6 +112,8 @@ export async function updatePost(
       .returning("*");
 
     if (
+      // NOTE: Skip notifying users if roadmap is removed/empty
+      newRoadmapId &&
       body.output.roadmap?.notifyVoters &&
       currentRoadmapId !== newRoadmapId
     ) {

--- a/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
+++ b/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
@@ -68,14 +68,31 @@
         </div>
         <SearchRoadmapDropdown
           :roadmap="post.roadmap"
-          @selected="selectRoadmap" />
+          @selected="selectRoadmap"
+        />
+        <div
+          :class="[
+            isRoadmapModified ? 'text-neutral-800' : 'text-neutral-400',
+            'flex items-center justify-between mt-2'
+          ]"
+        >
+          <div class="text-sm">
+            Notify voters about this change?
+          </div>
+
+          <Checkbox
+            :modelValue="notifyVoters.roadmap"
+            @update:modelValue="notifyVoters.roadmap = $event"
+            :disabled="!isRoadmapModified"
+          />
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive } from "vue";
+import { computed, reactive, ref } from "vue";
 import type { IDashboardPost } from "@logchimp/types";
 import { storeToRefs } from "pinia";
 
@@ -98,6 +115,7 @@ import { MAX_TITLE_LENGTH } from "../../../../constants";
 import InputLabel from "../../../ui/input/InputLabel.vue";
 import LicenseCrown from "../../../../ee/components/icons/LicenseCrown.vue";
 import UpgradeTooltip from "../../../../ee/components/UpgradeTooltip.vue";
+import Checkbox from "../../../ui/Checkbox.vue";
 
 const dashboardPosts = useDashboardPosts();
 const settingsEEStore = useSettingsEEStore();
@@ -114,11 +132,16 @@ const saveBtnLoading = ref(false);
 const post = reactive<IDashboardPost>({
   ...props.post,
 });
-
+const notifyVoters = reactive({
+  roadmap: false,
+});
 const postFieldError = reactive({
   show: false,
   message: "",
 });
+const isRoadmapModified = computed(
+  () => post.roadmap?.id !== props.post.roadmap?.id,
+);
 
 function hideTitleError(event: FormFieldErrorType) {
   postFieldError.show = event.show;
@@ -143,6 +166,9 @@ async function updatePostHandler() {
       userId: post.author.userId,
       boardId: post.board ? post.board.boardId : null,
       roadmapId: post.roadmap ? post.roadmap.id : null,
+      roadmap: {
+        notifyVoters: notifyVoters.roadmap,
+      },
     });
 
     Object.assign(post, response.data.post);

--- a/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
+++ b/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
@@ -126,7 +126,10 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const emit = defineEmits<(e: "loading", value: boolean) => void>();
+const emit = defineEmits<{
+  loading: [value: boolean];
+  updated: [post: IDashboardPost];
+}>();
 
 const saveBtnLoading = ref(false);
 const post = reactive<IDashboardPost>({
@@ -173,6 +176,8 @@ async function updatePostHandler() {
 
     Object.assign(post, response.data.post);
     dashboardPosts.updatePost(post);
+    emit("updated", post);
+    notifyVoters.roadmap = false;
   } catch (err) {
     console.error(err);
   } finally {

--- a/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
+++ b/packages/theme/src/components/dashboard/posts/PostEditor/index.vue
@@ -76,11 +76,12 @@
             'flex items-center justify-between mt-2'
           ]"
         >
-          <div class="text-sm">
+          <label class="text-sm" :for="notifyVotersRoadmap">
             Notify voters about this change?
-          </div>
+          </label>
 
           <Checkbox
+            :aria-labelledby="notifyVotersRoadmap"
             :modelValue="notifyVoters.roadmap"
             @update:modelValue="notifyVoters.roadmap = $event"
             :disabled="!isRoadmapModified"
@@ -92,7 +93,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from "vue";
+import { computed, reactive, ref, useId } from "vue";
 import type { IDashboardPost } from "@logchimp/types";
 import { storeToRefs } from "pinia";
 
@@ -130,6 +131,7 @@ const emit = defineEmits<{
   loading: [value: boolean];
   updated: [post: IDashboardPost];
 }>();
+const notifyVotersRoadmap = useId();
 
 const saveBtnLoading = ref(false);
 const post = reactive<IDashboardPost>({

--- a/packages/theme/src/components/dashboard/posts/PostViewer.vue
+++ b/packages/theme/src/components/dashboard/posts/PostViewer.vue
@@ -36,6 +36,7 @@
       <DashboardPostEditor
         ref="dashboardPostEditorRef"
         :post="post"
+        @updated="handlePostUpdated"
         @loading="loading = $event"
       />
 
@@ -86,6 +87,9 @@ interface Props {
   post: IDashboardPost;
 }
 defineProps<Props>();
+const emit = defineEmits<{
+  updated: [post: IDashboardPost];
+}>();
 
 const loading = ref(false);
 const dashboardPostEditorRef = ref();
@@ -97,6 +101,10 @@ const hasPermission = computed(() => {
 
 function updatePostHandler() {
   dashboardPostEditorRef.value.updatePostHandler();
+}
+
+function handlePostUpdated(updatedPost: IDashboardPost) {
+  emit("updated", updatedPost);
 }
 
 onMounted(() => {

--- a/packages/theme/src/components/ui/Checkbox.vue
+++ b/packages/theme/src/components/ui/Checkbox.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { CheckboxIndicator, CheckboxRoot } from "reka-ui";
+import { CheckIcon } from "lucide-vue";
+
+defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits(["update:modelValue"]);
+</script>
+
+<template>
+  <CheckboxRoot
+    :modelValue="modelValue"
+    @update:modelValue="$emit('update:modelValue', $event)"
+    :disabled="disabled"
+    :class="[
+      'hover:bg-neutral-50 size-5 appearance-none',
+      'flex items-center justify-center rounded-(--border-radius-default) border outline-none',
+      'not-disabled:bg-white not-disabled:border-gray-400',
+      'disabled:bg-gray-200/80 disabled:border-gray-300 disabled:cursor-not-allowed'
+    ]"
+  >
+    <CheckboxIndicator
+      class="size-full rounded flex items-center justify-center"
+    >
+      <CheckIcon class="size-4 text-gray-700 stroke-3" />
+    </CheckboxIndicator>
+  </CheckboxRoot>
+</template>

--- a/packages/theme/src/pages/dashboard/posts/_slug/Index.vue
+++ b/packages/theme/src/pages/dashboard/posts/_slug/Index.vue
@@ -14,6 +14,7 @@
     <DashboardPostViewer
       v-else-if="post.postId"
       :post="post"
+      @updated="handlePostUpdated"
     />
     <Dashboard500 v-else>
       Something went wrong.
@@ -101,6 +102,10 @@ onMounted(() => {
     router.push("/dashboard/posts");
   }
 });
+
+function handlePostUpdated(updatedPost: IDashboardPost) {
+  Object.assign(post, updatedPost);
+}
 
 useHead({
   title: () => `${post.title ? `${post.title} • ` : ""}Post • Dashboard`,

--- a/packages/types/src/posts/post.ts
+++ b/packages/types/src/posts/post.ts
@@ -78,6 +78,9 @@ export interface IUpdatePostRequestBody {
   userId: string;
   boardId?: string | null;
   roadmapId?: string | null;
+  roadmap?: {
+    notifyVoters: boolean;
+  };
 }
 
 export type TUpdatePostResponseBody = ICreatePostResponseBody;


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to notify voters when changing a post’s roadmap.
  * The notification option is available only when the roadmap changes and resets after saving.
  * Added checkbox controls with disabled-state support.
* **Improvements**
  * Posts can now be assigned to or removed from a roadmap.
  * Updated post details now appear immediately throughout the dashboard after saving.
  * Roadmap-change notifications are sent only when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->