### PR TITLE
lc sso/3 db migrations

### DIFF
--- a/packages/server/src/database/migrations/20260824124800_nullable-password-column-in-users-table.ts
+++ b/packages/server/src/database/migrations/20260824124800_nullable-password-column-in-users-table.ts
@@ -16,7 +16,7 @@ export async function up(knex: Knex): Promise<void> {
       code: "DATABASE_MIGRATIONS",
       message:
         "Failed to change 'password' column to nullable in 'users' table",
-      error: err,
+      err,
     });
     throw err;
   }
@@ -47,7 +47,7 @@ export async function down(knex: Knex): Promise<void> {
       code: "DATABASE_MIGRATIONS",
       message:
         "Failed to change 'password' column not nullable in 'users' table",
-      error: err,
+      err,
     });
     throw err;
   }

--- a/packages/server/src/database/migrations/20260824124800_nullable-password-column-in-users-table.ts
+++ b/packages/server/src/database/migrations/20260824124800_nullable-password-column-in-users-table.ts
@@ -3,30 +3,20 @@ import logger from "../../utils/logger";
 
 export async function up(knex: Knex): Promise<void> {
   try {
-    const userWithoutPassword = await knex("users")
-      .whereNull("password")
-      .first("userId");
-
-    if (userWithoutPassword) {
-      throw new Error(
-        "Cannot restore NOT NULL on users.password while users without passwords exist.",
-      );
-    }
-
     await knex.schema.alterTable("users", (t) => {
-      t.dropNullable("password");
+      t.setNullable("password");
     });
 
     logger.info({
       code: "DATABASE_MIGRATIONS",
-      message: "Change 'password' column to NOT NULL in 'users' table",
+      message: "Change 'password' column to nullable in 'users' table",
     });
   } catch (err) {
     logger.error({
       code: "DATABASE_MIGRATIONS",
       message:
-        "Failed to change 'password' column to NOT NULL in 'users' table",
-      err,
+        "Failed to change 'password' column to nullable in 'users' table",
+      error: err,
     });
     throw err;
   }

--- a/packages/server/src/database/migrations/20260824124800_nullable-password-column-in-users-table.ts
+++ b/packages/server/src/database/migrations/20260824124800_nullable-password-column-in-users-table.ts
@@ -1,0 +1,64 @@
+import type { Knex } from "knex";
+import logger from "../../utils/logger";
+
+export async function up(knex: Knex): Promise<void> {
+  try {
+    const userWithoutPassword = await knex("users")
+      .whereNull("password")
+      .first("userId");
+
+    if (userWithoutPassword) {
+      throw new Error(
+        "Cannot restore NOT NULL on users.password while users without passwords exist.",
+      );
+    }
+
+    await knex.schema.alterTable("users", (t) => {
+      t.dropNullable("password");
+    });
+
+    logger.info({
+      code: "DATABASE_MIGRATIONS",
+      message: "Change 'password' column to NOT NULL in 'users' table",
+    });
+  } catch (err) {
+    logger.error({
+      code: "DATABASE_MIGRATIONS",
+      message:
+        "Failed to change 'password' column to NOT NULL in 'users' table",
+      err,
+    });
+    throw err;
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  try {
+    const userWithoutPassword = await knex("users")
+      .whereNull("password")
+      .first("userId");
+
+    if (userWithoutPassword) {
+      throw new Error(
+        "Cannot restore NOT NULL on users.password while users without passwords exist.",
+      );
+    }
+
+    await knex.schema.alterTable("users", (t) => {
+      t.dropNullable("password");
+    });
+
+    logger.info({
+      code: "DATABASE_MIGRATIONS",
+      message: "Change 'password' column not nullable in 'users' table",
+    });
+  } catch (err) {
+    logger.error({
+      code: "DATABASE_MIGRATIONS",
+      message:
+        "Failed to change 'password' column not nullable in 'users' table",
+      error: err,
+    });
+    throw err;
+  }
+}

--- a/packages/server/src/database/migrations/20260827124621_create-auth-identities-table.ts
+++ b/packages/server/src/database/migrations/20260827124621_create-auth-identities-table.ts
@@ -1,0 +1,56 @@
+import type { Knex } from "knex";
+import logger from "../../utils/logger";
+
+export async function up(knex: Knex): Promise<void> {
+  try {
+    await knex.schema.createTable("auth_identities", (t) => {
+      t.string("id").primary();
+      t.uuid("user_id")
+        .notNullable()
+        .references("userId")
+        .inTable("users")
+        .onDelete("CASCADE");
+      t.string("provider").notNullable();
+      t.string("subject").notNullable();
+      t.string("email").notNullable();
+      t.boolean("email_verified").notNullable().defaultTo(false);
+      t.dateTime("updated_at");
+      t.dateTime("created_at").notNullable().defaultTo(knex.fn.now());
+
+      t.unique(["provider", "subject"], {
+        indexName: "auth_identities_provider_subject_unique",
+      });
+      t.index(["user_id"], "auth_identities_user_id_idx");
+    });
+
+    logger.info({
+      code: "DATABASE_MIGRATIONS",
+      message: "Created 'auth_identities' table",
+    });
+  } catch (err) {
+    logger.error({
+      code: "DATABASE_MIGRATIONS",
+      message: "Failed to create 'auth_identities' table",
+      err,
+    });
+    throw err;
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  try {
+    await knex.schema.dropTable("auth_identities");
+
+    logger.info({
+      code: "DATABASE_MIGRATIONS",
+      message: "Dropped 'auth_identities' table",
+    });
+  } catch (err) {
+    logger.error({
+      code: "DATABASE_MIGRATIONS",
+      message: "Failed to drop 'auth_identities' table",
+      err,
+    });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds few database migrations:

1. Make `password` column nullable
2. Add `auth_identities` table

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for linking multiple authentication identities to user accounts.
  - Authentication identities include provider details, verification status, and account associations.
  - Enabled passwordless account configurations by allowing accounts without a stored password.

- **Improvements**
  - Improved authentication data management and account compatibility.
  - Added safeguards when restoring password requirements to prevent invalid account states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->