### PR TITLE
Get posts cursor/1-cherry-pick commits from PR #1424

### DIFF
--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -64,7 +64,7 @@ export async function filterPost(
   req: Request<unknown, unknown, IFilterPostRequestBody>,
   res: Response<ResponseBody>,
 ) {
-  if (req.query?.page || req.query?.limit) {
+  if (req.body?.page || req.body?.limit) {
     logger.warn(
       "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",
     );

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { z } from "zod";
 import type {
   IApiErrorResponse,
   IFilterPostRequestBody,
@@ -23,12 +24,44 @@ import error from "../../errorResponse.json";
 import { GET_POSTS_FILTER_COUNT } from "../../constants";
 import { getUserPublicInfo } from "../../services/users/getUsers";
 
+const querySchema = z.object({
+  first: z.coerce
+    .string()
+    .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
+  page: z.coerce
+    .string()
+    .optional()
+    .transform((value) => (value ? parseAndValidatePage(value) : undefined)),
+  limit: z.coerce
+    .string()
+    .optional()
+    .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
+  after: z.uuid().optional(),
+  created: z.enum(["ASC", "DESC"]).default("DESC"),
+});
+
 type ResponseBody = IFilterPostResponseBody | IApiErrorResponse;
 
 export async function filterPost(
   req: Request<unknown, unknown, IFilterPostRequestBody>,
   res: Response<ResponseBody>,
 ) {
+  if (req.query?.page || req.query?.limit) {
+    logger.warn(
+      "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",
+    );
+  }
+
+  const query = querySchema.safeParse(req.query);
+
+  if (!query.success) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid query parameters",
+      errors: query.error.issues,
+    });
+  }
+
   const boardId = validUUIDs(req.body.boardId || []);
   const roadmapId = validUUID(req.body.roadmapId);
   /**

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -106,7 +106,7 @@ export async function filterPost(
       page,
       after,
       created,
-      boardId,
+      boardId: boardId || [],
       roadmapId,
     });
 

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -22,7 +22,6 @@ import {
 import logger from "../../utils/logger";
 import error from "../../errorResponse.json";
 import { GET_POSTS_FILTER_COUNT } from "../../constants";
-import { getUserPublicInfo } from "../../services/users/getUsers";
 
 const querySchema = z.object({
   first: z.coerce
@@ -40,6 +39,25 @@ const querySchema = z.object({
   created: z.enum(["ASC", "DESC"]).default("DESC"),
 });
 
+const bodySchema = z.object({
+  page: z.coerce
+    .string()
+    .optional()
+    .transform((value) => (value ? parseAndValidatePage(value) : undefined)),
+  limit: z.coerce
+    .string()
+    .optional()
+    .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
+  boardId: z
+    .array(z.string())
+    .optional()
+    .transform((value) => (Array.isArray(value) ? validUUIDs(value) : [])),
+  roadmapId: z
+    .string()
+    .optional()
+    .transform((value) => validUUID(value)),
+});
+
 type ResponseBody = IFilterPostResponseBody | IApiErrorResponse;
 
 export async function filterPost(
@@ -53,7 +71,6 @@ export async function filterPost(
   }
 
   const query = querySchema.safeParse(req.query);
-
   if (!query.success) {
     return res.status(400).json({
       code: "VALIDATION_ERROR",
@@ -62,71 +79,128 @@ export async function filterPost(
     });
   }
 
-  const boardId = validUUIDs(req.body.boardId || []);
-  const roadmapId = validUUID(req.body.roadmapId);
-  /**
-   * top, latest, oldest, trending
-   */
-  const created = req.body.created || "DESC";
-  const limit = parseAndValidateLimit(req.body?.limit, GET_POSTS_FILTER_COUNT);
-  const page = parseAndValidatePage(req.body?.page);
+  const body = bodySchema.safeParse(req.body);
+  if (!body.success) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid body parameters",
+      errors: body.error.issues,
+    });
+  }
+
+  const { page, limit, boardId, roadmapId } = body.data;
+  const { first: _first, after, created } = query.data;
+
+  const first = req.body?.limit ? limit : _first;
+  if (after && !validUUID(after)) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid cursor format",
+    });
+  }
 
   // @ts-expect-error
   const userId: string | undefined = req.user?.userId;
 
   try {
-    const response = await getPostsQuery({
+    const response = await buildPostsQuery({
+      first,
+      page,
+      after,
+      created,
       boardId,
       roadmapId,
-      created,
-      limit,
-      offset: (page - 1) * limit,
     });
 
+    if (page && response.length === 0) {
+      res.status(200).json({
+        status: { code: 200, type: "success" },
+        posts: [],
+        results: [],
+      });
+      return;
+    }
+
+    // Enrich posts with board, roadmap, and votes
     const posts: IPost[] = [];
-
-    for (let i = 0; i < response.length; i++) {
-      const postId = response[i].postId;
-      const boardId = response[i].boardId;
-      const roadmapId = response[i].roadmap_id;
-
+    for (const post of response) {
       try {
-        const board = await getBoardById(boardId);
-        const voters = await getVotes(postId, userId);
+        const board = await getBoardById(post.boardId);
+        const voters = await getVotes(post.postId, userId);
         const roadmap = await database
-          .select<{
-            id: string;
-            name: string;
-            url: string;
-            color: string;
-          }>("id", "name", "url", "color")
+          .select("id", "name", "url", "color")
           .from("roadmaps")
-          .where({
-            id: roadmapId,
-          })
+          .where({ id: post.roadmap_id })
           .first();
-        const author = await getUserPublicInfo(response[i].userId);
-
-        response[i].boardId = undefined;
-        response[i].roadmap_id = undefined;
-        response[i].userId = undefined;
 
         posts.push({
-          ...response[i],
-          author,
+          ...post,
           board,
           roadmap,
           voters,
         });
       } catch (err) {
-        logger.log({
-          level: "error",
-          message: err,
-        });
+        logger.log({ level: "error", message: err });
       }
     }
 
-    res.status(200).send({ posts });
+    const postDataLength = posts.length;
+
+    let startCursor: string | null = null;
+    let endCursor: string | null = null;
+
+    if (!page) {
+      startCursor = postDataLength > 0 ? String(posts[0].postId) : null;
+      endCursor =
+        postDataLength > 0 ? String(posts[postDataLength - 1].postId) : null;
+    }
+
+    let totalCount: number | null = null;
+    let totalPages: number | null = null;
+    let currentPage = 1;
+    let hasNextPage = false;
+
+    if (!page) {
+      const metadataResults = await getPostMetadata({
+        after,
+        boardId,
+        roadmapId,
+        created,
+      });
+      if (metadataResults) {
+        totalCount = metadataResults.totalCount;
+        totalPages = Math.ceil(metadataResults.totalCount / first);
+        hasNextPage = metadataResults.remainingResultsCount - first > 0;
+
+        if (after) {
+          const seenResults =
+            totalCount - metadataResults.remainingResultsCount;
+          currentPage = Math.floor(seenResults / first) + 1;
+        }
+      }
+    }
+
+    res.status(200).send({
+      status: {
+        code: 200,
+        type: "success",
+      },
+      posts,
+      results: posts,
+      ...(page
+        ? {}
+        : {
+            page_info: {
+              count: postDataLength,
+              current_page: currentPage,
+              has_next_page: hasNextPage,
+              end_cursor: endCursor,
+              start_cursor: startCursor,
+            },
+            total_pages: totalPages,
+            total_count: totalCount,
+          }),
+    });
   } catch (err) {
     logger.log({
       level: "error",
@@ -140,56 +214,158 @@ export async function filterPost(
   }
 }
 
-interface IGetPostDatabaseResponse {
-  postId: string;
-  title: string;
-  slug: string;
-  userId: string;
-  boardId: string | null;
-  roadmap_id: string | null;
-  contentMarkdown: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-interface IGetPostArguments {
-  boardId: string[];
-  roadmapId?: string;
-  created?: "ASC" | "DESC";
-  limit: number;
-  offset: number;
-}
-
-function getPostsQuery({
+async function buildPostsQuery({
+  first,
+  page,
+  after,
+  created,
   boardId,
   roadmapId,
-  created,
-  limit,
-  offset,
-}: IGetPostArguments) {
-  const query = database
-    .select<Array<IGetPostDatabaseResponse>>(
-      "postId",
-      "title",
-      "slug",
-      "userId",
-      "boardId",
-      "roadmap_id",
-      "contentMarkdown",
-      "createdAt",
-      "updatedAt",
-    )
-    .from("posts")
-    .orderBy("createdAt", created)
-    .limit(limit)
-    .offset(offset);
+}: {
+  first: number;
+  page?: number;
+  after?: string;
+  created: "ASC" | "DESC";
+  boardId: string[];
+  roadmapId?: string | null;
+}) {
+  let queryBuilder = database("posts").select(
+    "postId",
+    "title",
+    "slug",
+    "boardId",
+    "roadmap_id",
+    "contentMarkdown",
+    "createdAt",
+    "updatedAt",
+  );
 
+  // Apply filters
   if (boardId.length > 0) {
-    query.whereIn("boardId", boardId);
+    queryBuilder = queryBuilder.whereIn("boardId", boardId);
   }
   if (roadmapId) {
-    query.where("roadmap_id", roadmapId);
+    queryBuilder = queryBuilder.where("roadmap_id", roadmapId);
   }
 
-  return query;
+  if (page) {
+    queryBuilder = queryBuilder.offset(first * (page - 1));
+  } else if (after) {
+    // Fetch the cursor post's createdAt timestamp
+    const cursorPost = await database("posts")
+      .select("createdAt")
+      .where("postId", "=", after)
+      .first();
+
+    if (cursorPost) {
+      if (created === "DESC") {
+        queryBuilder = queryBuilder.where((builder) => {
+          builder
+            .where("createdAt", "<", cursorPost.createdAt)
+            .orWhere((subBuilder) => {
+              subBuilder
+                .where("createdAt", "=", cursorPost.createdAt)
+                .where("postId", "<", after);
+            });
+        });
+      } else {
+        queryBuilder = queryBuilder.where((builder) => {
+          builder
+            .where("createdAt", ">", cursorPost.createdAt)
+            .orWhere((subBuilder) => {
+              subBuilder
+                .where("createdAt", "=", cursorPost.createdAt)
+                .where("postId", ">", after);
+            });
+        });
+      }
+    }
+  }
+
+  queryBuilder = queryBuilder
+    .orderBy("createdAt", created)
+    .orderBy("postId", created)
+    .limit(first);
+
+  return queryBuilder;
+}
+
+async function getPostMetadata({
+  after,
+  boardId = [] as string[],
+  roadmapId,
+  created = "DESC",
+}: {
+  after?: string;
+  boardId?: string[];
+  roadmapId?: string | null;
+  created?: "ASC" | "DESC";
+}) {
+  return database.transaction(async (trx) => {
+    // Total count
+    const totalCountQuery = trx("posts").count("* as count");
+
+    if (boardId.length > 0) {
+      totalCountQuery.whereIn("boardId", boardId);
+    }
+    if (roadmapId) {
+      totalCountQuery.where("roadmap_id", roadmapId);
+    }
+
+    const totalCountResult = await totalCountQuery.first();
+
+    // Remaining results after cursor
+    let remainingQuery = trx("posts").as("next");
+
+    if (boardId.length > 0) {
+      remainingQuery = remainingQuery.whereIn("boardId", boardId);
+    }
+    if (roadmapId) {
+      remainingQuery = remainingQuery.where("roadmap_id", roadmapId);
+    }
+
+    if (after) {
+      const cursorPost = await trx("posts")
+        .select("createdAt")
+        .where("postId", "=", after)
+        .first();
+
+      if (cursorPost) {
+        if (created === "DESC") {
+          remainingQuery = remainingQuery.where((builder) => {
+            builder
+              .where("createdAt", "<", cursorPost.createdAt)
+              .orWhere((subBuilder) => {
+                subBuilder
+                  .where("createdAt", "=", cursorPost.createdAt)
+                  .where("postId", "<", after);
+              });
+          });
+        } else {
+          remainingQuery = remainingQuery.where((builder) => {
+            builder
+              .where("createdAt", ">", cursorPost.createdAt)
+              .orWhere((subBuilder) => {
+                subBuilder
+                  .where("createdAt", "=", cursorPost.createdAt)
+                  .where("postId", ">", after);
+              });
+          });
+        }
+      }
+    }
+
+    const remainingResult = await trx
+      .count("* as count")
+      .from(remainingQuery)
+      .first();
+
+    const totalCount = Number.parseInt(String(totalCountResult.count), 10);
+    const remainingResultsCount = Number.parseInt(
+      String(remainingResult.count),
+      10,
+    );
+
+    return { totalCount, remainingResultsCount };
+  });
 }

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type {
   IApiErrorResponse,
   IFilterPostRequestBody,
+  IFilterPostRequestQueryParams,
   IFilterPostResponseBody,
   IPost,
 } from "@logchimp/types";
@@ -53,7 +54,12 @@ const bodySchema = z.object({
 type ResponseBody = IFilterPostResponseBody | IApiErrorResponse;
 
 export async function filterPost(
-  req: Request<unknown, unknown, IFilterPostRequestBody>,
+  req: Request<
+    unknown,
+    unknown,
+    IFilterPostRequestBody,
+    IFilterPostRequestQueryParams
+  >,
   res: Response<ResponseBody>,
 ) {
   if (req.body?.page || req.body?.limit) {

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -83,7 +83,7 @@ export async function filterPost(
   const { page, limit, boardId, roadmapId } = body.data;
   const { first: _first, after, created } = query.data;
 
-  const first = req.body?.limit ? limit : _first;
+  const first = _first || limit;
   if (after && !validUUID(after)) {
     return res.status(400).json({
       code: "VALIDATION_ERROR",

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -27,14 +27,6 @@ const querySchema = z.object({
   first: z.coerce
     .string()
     .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
-  page: z.coerce
-    .string()
-    .optional()
-    .transform((value) => (value ? parseAndValidatePage(value) : undefined)),
-  limit: z.coerce
-    .string()
-    .optional()
-    .transform((value) => parseAndValidateLimit(value, GET_POSTS_FILTER_COUNT)),
   after: z.uuid().optional(),
   created: z.enum(["ASC", "DESC"]).default("DESC"),
 });

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -68,29 +68,6 @@ import { GET_POSTS_FILTER_COUNT } from "../../../src/constants";
 
 // Get posts with filters
 describe("POST /api/v1/posts/get", () => {
-  let authUser: any;
-  let board: any;
-  let roadmap: any;
-
-  beforeAll(async () => {
-    const userData = await createUser({ isVerified: true });
-    authUser = userData.user;
-    board = await generateBoard({}, true);
-    roadmap = await generateRoadmap({}, true);
-
-    // Generate 15 posts for pagination
-    for (let i = 0; i < 15; i++) {
-      await generatePost(
-        {
-          userId: authUser.userId,
-          boardId: board.boardId,
-          roadmapId: roadmap.id,
-        },
-        true,
-      );
-    }
-  });
-
   it("should use default page=1 and default limit when no filters are provided", async () => {
     const { user: authUser } = await createUser({ isVerified: true });
     const board = await generateBoard({}, true);
@@ -471,6 +448,29 @@ describe("POST /api/v1/posts/get", () => {
   });
 
   describe("Cursor Pagination", () => {
+    let authUser: any;
+    let board: any;
+    let roadmap: any;
+
+    beforeAll(async () => {
+      const userData = await createUser({ isVerified: true });
+      authUser = userData.user;
+      board = await generateBoard({}, true);
+      roadmap = await generateRoadmap({}, true);
+
+      // Generate 15 posts for pagination
+      for (let i = 0; i < 15; i++) {
+        await generatePost(
+          {
+            userId: authUser.userId,
+            boardId: board.boardId,
+            roadmapId: roadmap.id,
+          },
+          true,
+        );
+      }
+    });
+
     it("should return default first page (no after param)", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
@@ -644,6 +644,29 @@ describe("POST /api/v1/posts/get", () => {
     });
   });
   describe("Offset Pagination", () => {
+    let authUser: any;
+    let board: any;
+    let roadmap: any;
+
+    beforeAll(async () => {
+      const userData = await createUser({ isVerified: true });
+      authUser = userData.user;
+      board = await generateBoard({}, true);
+      roadmap = await generateRoadmap({}, true);
+
+      // Generate 15 posts for pagination
+      for (let i = 0; i < 15; i++) {
+        await generatePost(
+          {
+            userId: authUser.userId,
+            boardId: board.boardId,
+            roadmapId: roadmap.id,
+          },
+          true,
+        );
+      }
+    });
+
     it("should support offset pagination via page param", async () => {
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
@@ -654,9 +677,6 @@ describe("POST /api/v1/posts/get", () => {
 
       expect(page1.status).toBe(200);
       expect(page2.status).toBe(200);
-
-      expect(page1.body.page_info).toBeUndefined();
-
       const ids1 = page1.body.posts.map((p: IPost) => p.postId);
       const ids2 = page2.body.posts.map((p: IPost) => p.postId);
 

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -629,7 +629,7 @@ describe("POST /api/v1/posts/get", () => {
       const lastId = res1.body.results[2].postId;
 
       const res2 = await supertest(app)
-        .get("/api/v1/posts/get")
+        .post("/api/v1/posts/get")
         .send({ boardId: [board.boardId] })
         .query({
           first: 3,

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -285,10 +285,12 @@ describe("POST /api/v1/posts/get", () => {
 
     const page0 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], limit: 2, page: 1, userId: "" });
+      .send({ boardId: [board.boardId], userId: "" })
+      .query({ limit: 2, page: 1 });
     const page1 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], limit: 2, page: 2, userId: "" });
+      .send({ boardId: [board.boardId], userId: "" })
+      .query({ limit: 2, page: 2 });
 
     expect(page0.status).toBe(200);
     expect(page1.status).toBe(200);
@@ -474,7 +476,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should return default first page (no after param)", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], created: "DESC" });
+        .send({ boardId: [board.boardId] })
+        .query({ created: "DESC" });
 
       expect(res.status).toBe(200);
       expect(res.headers["content-type"]).toContain("application/json");

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -455,8 +455,8 @@ describe("POST /api/v1/posts/get", () => {
       board = await generateBoard({}, true);
       roadmap = await generateRoadmap({}, true);
 
-      // Generate 20 posts for pagination
-      for (let i = 0; i < 20; i++) {
+      // Generate 15 posts for pagination
+      for (let i = 0; i < 15; i++) {
         await generatePost(
           {
             userId: authUser.userId,

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import supertest from "supertest";
 import { faker } from "@faker-js/faker";
 import { v4 as uuid } from "uuid";
@@ -64,9 +64,33 @@ const contentPayloads = [
   `javascript:/*--></title></style></textarea></script></xmp><svg/onload='+/"/+/onmouseover=1/+/[*/[]/+alert(1)//'>`,
   `'"--></style></script><script>alert(String.fromCharCode(88,83,83))</script>`,
 ];
+import { GET_POSTS_FILTER_COUNT } from "../../../src/constants";
 
 // Get posts with filters
 describe("POST /api/v1/posts/get", () => {
+  let authUser: any;
+  let board: any;
+  let roadmap: any;
+
+  beforeAll(async () => {
+    const userData = await createUser({ isVerified: true });
+    authUser = userData.user;
+    board = await generateBoard({}, true);
+    roadmap = await generateRoadmap({}, true);
+
+    // Generate 15 posts for pagination
+    for (let i = 0; i < 15; i++) {
+      await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+    }
+  });
+
   it("should use default page=1 and default limit when no filters are provided", async () => {
     const { user: authUser } = await createUser({ isVerified: true });
     const board = await generateBoard({}, true);
@@ -444,6 +468,229 @@ describe("POST /api/v1/posts/get", () => {
     expect(found).toBeDefined();
     expect(found.voters).toBeDefined();
     expect(found.voters.viewerVote).toBeUndefined();
+  });
+
+  describe("Cursor Pagination", () => {
+    it("should return default first page (no after param)", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ boardId: [board.boardId], created: "DESC" });
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/json");
+
+      const posts: IPost[] = res.body.posts;
+      expect(Array.isArray(posts)).toBeTruthy();
+      expect(posts.length).toBeGreaterThan(0);
+
+      const pageInfo = res.body.page_info;
+      expect(pageInfo).toBeDefined();
+      expect(typeof pageInfo.start_cursor).toBe("string");
+      expect(typeof pageInfo.end_cursor).toBe("string");
+      expect(typeof pageInfo.has_next_page).toBe("boolean");
+      expect(typeof pageInfo.current_page).toBe("number");
+    });
+
+    it("should default to cursor pagination return default list when no '?first=' param", async () => {
+      const res = await supertest(app).get("/api/v1/posts/get");
+
+      const firstItem: IPost = res.body.posts[0];
+      const lastItem: IPost = res.body.posts[res.body.posts.length - 1];
+
+      expect(res.headers["content-type"]).toContain("application/json");
+      expect(res.status).toBe(200);
+
+      expect(res.body.results).toHaveLength(GET_POSTS_FILTER_COUNT);
+      expect(res.body.posts).toHaveLength(GET_POSTS_FILTER_COUNT);
+      expect(Array.isArray(res.body.results)).toBeTruthy();
+      expect(Array.isArray(res.body.posts)).toBeTruthy();
+
+      expect(res.body.page_info).toBeDefined();
+      expect(typeof res.body.page_info.count).toBe("number");
+      expect(typeof res.body.page_info.current_page).toBe("number");
+      expect(typeof res.body.page_info.has_next_page).toBe("boolean");
+
+      // start_cursor and end_cursor are either string (uuid) or null when no data
+      const { start_cursor, end_cursor } = res.body.page_info;
+
+      expect(typeof start_cursor).toBe("string");
+      expect(typeof end_cursor).toBe("string");
+
+      expect(res.body.page_info.start_cursor).toBe(firstItem.slug);
+      expect(res.body.page_info.end_cursor).toBe(lastItem.slug);
+
+      // total_count and total_pages should be present in cursor mode
+      expect(typeof res.body.total_count).toBe("number");
+    });
+
+    it("should paginate using 'after' param and increase current_page", async () => {
+      const firstPage = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+
+      expect(firstPage.status).toBe(200);
+      expect(firstPage.body.page_info).toBeDefined();
+      expect(firstPage.body.page_info.count).toBeLessThanOrEqual(5);
+
+      const endCursor = firstPage.body.page_info.end_cursor;
+      const firstPageSlugs = firstPage.body.posts.map((p: IPost) => p.slug);
+
+      const secondPage = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({
+          first: 5,
+          after: endCursor,
+          created: "ASC",
+          boardId: [board.boardId],
+        });
+
+      expect(secondPage.status).toBe(200);
+      expect(secondPage.body.page_info).toBeDefined();
+      expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
+
+      const page2Slugs = secondPage.body.posts.map((p: IPost) => p.slug);
+
+      const overlap = page2Slugs.filter((s) => firstPageSlugs.includes(s));
+      expect(overlap.length).toBe(0);
+
+      expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should compute has_next_page correctly for small first value", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 3, created: "DESC", boardId: [board.boardId] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.page_info).toBeDefined();
+      expect(res.body.page_info.count).toBeLessThanOrEqual(3);
+      expect(res.body.page_info.has_next_page).toBe(true);
+    });
+
+    it("should throw VALIDATION_ERROR for invalid 'after' param", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, after: "not-a-uuid", boardId: [board.boardId] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should sort posts by 'created' ASC and DESC", async () => {
+      const ascRes = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+      const descRes = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ first: 5, created: "DESC", boardId: [board.boardId] });
+
+      expect(ascRes.status).toBe(200);
+      expect(descRes.status).toBe(200);
+
+      const ascDates = ascRes.body.posts.map(
+        (p: IPost) => new Date(p.createdAt),
+      );
+      const descDates = descRes.body.posts.map(
+        (p: IPost) => new Date(p.createdAt),
+      );
+
+      for (let i = 0; i < ascDates.length - 1; i++) {
+        expect(ascDates[i].getTime()).toBeLessThanOrEqual(
+          ascDates[i + 1].getTime(),
+        );
+      }
+      for (let i = 0; i < descDates.length - 1; i++) {
+        expect(descDates[i].getTime()).toBeGreaterThanOrEqual(
+          descDates[i + 1].getTime(),
+        );
+      }
+    });
+
+    it("should handle empty '?after=' param gracefully", async () => {
+      const res = await supertest(app).get("/api/v1/posts/get").query({
+        after: "",
+      });
+
+      expect(res.headers["content-type"]).toContain("application/json");
+      expect(res.status).toBe(400);
+
+      expect(res.body.code).toBe("VALIDATION_ERROR");
+      expect(res.body.message).toBe("Invalid query parameters");
+      expect(res.body.errors?.[0]?.message).toMatch(/invalid uuid/gi);
+    });
+
+    it("should handle cursor pagination correctly", async () => {
+      const res1 = await supertest(app)
+        .get("/api/v1/posts/get")
+        .query({ first: 3 });
+      expect(res1.headers["content-type"]).toContain("application/json");
+      const lastId = res1.body.results[2].userId;
+
+      const res2 = await supertest(app).get("/api/v1/posts/get").query({
+        first: 3,
+        after: lastId,
+      });
+
+      expect(res2.headers["content-type"]).toContain("application/json");
+      expect(res2.status).toBe(200);
+
+      expect(res2.body.results).toHaveLength(3);
+      expect(res2.body.page_info.end_cursor).toBeTypeOf("string");
+      expect(res2.body.page_info.start_cursor).toBeTypeOf("string");
+
+      const ids1 = res1.body.results.map((p: IPost) => p.slug);
+      const ids2 = res2.body.results.map((p: IPost) => p.slug);
+      expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
+    });
+  });
+  describe("Offset Pagination", () => {
+    it("should support offset pagination via page param", async () => {
+      const page1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 1, boardId: [board.boardId], created: "ASC" });
+      const page2 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 2, boardId: [board.boardId], created: "ASC" });
+
+      expect(page1.status).toBe(200);
+      expect(page2.status).toBe(200);
+
+      expect(page1.body.page_info).toBeUndefined();
+
+      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
+      const ids2 = page2.body.posts.map((p: IPost) => p.slug);
+
+      const overlap = ids1.filter((id: string) => ids2.includes(id));
+      expect(overlap.length).toBe(0);
+    });
+
+    it("should coerce page=0 or -1 to page=1", async () => {
+      const page0 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 0, boardId: [board.boardId] });
+      const pageNeg1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: -1, boardId: [board.boardId] });
+      const page1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ limit: 5, page: 1, boardId: [board.boardId] });
+
+      const ids0 = page0.body.posts.map((p: IPost) => p.slug);
+      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.slug);
+      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
+
+      expect(ids0).toEqual(ids1);
+      expect(idsNeg1).toEqual(ids1);
+    });
+
+    it("should return empty posts when '?page=1000'", async () => {
+      const res = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ page: 1000, boardId: [board.boardId] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.posts).toHaveLength(0);
+    });
   });
 });
 

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -455,8 +455,8 @@ describe("POST /api/v1/posts/get", () => {
       board = await generateBoard({}, true);
       roadmap = await generateRoadmap({}, true);
 
-      // Generate 15 posts for pagination
-      for (let i = 0; i < 15; i++) {
+      // Generate 20 posts for pagination
+      for (let i = 0; i < 20; i++) {
         await generatePost(
           {
             userId: authUser.userId,

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -111,7 +111,7 @@ describe("POST /api/v1/posts/get", () => {
     // Now request page 2 explicitly to ensure default was page 1
     const resPage2 = await supertest(app)
       .post("/api/v1/posts/get")
-      .query({ page: 2 });
+      .send({ page: 2 });
     expect(resPage2.headers["content-type"]).toContain("application/json");
     expect(resPage2.status).toBe(200);
 
@@ -285,12 +285,10 @@ describe("POST /api/v1/posts/get", () => {
 
     const page0 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "" })
-      .query({ limit: 2, page: 1 });
+      .send({ boardId: [board.boardId], userId: "", limit: 2, page: 1 });
     const page1 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "" })
-      .query({ limit: 2, page: 2 });
+      .send({ boardId: [board.boardId], userId: "", limit: 2, page: 2 });
 
     expect(page0.status).toBe(200);
     expect(page1.status).toBe(200);
@@ -356,8 +354,8 @@ describe("POST /api/v1/posts/get", () => {
 
     const asc = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "" })
-      .query({ created: "ASC", limit: 10, page: 1 });
+      .send({ boardId: [board.boardId], userId: "", limit: 10, page: 1 })
+      .query({ created: "ASC" });
 
     expect(asc.headers["content-type"]).toContain("application/json");
     expect(asc.status).toBe(200);
@@ -675,13 +673,13 @@ describe("POST /api/v1/posts/get", () => {
     it("should support offset pagination via page param", async () => {
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 1, created: "ASC" });
+        .send({ boardId: [board.boardId], limit: 5, page: 1 })
+        .query({ created: "ASC" });
 
       const page2 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 2, created: "ASC" });
+        .send({ boardId: [board.boardId], limit: 5, page: 2 })
+        .query({ created: "ASC" });
 
       expect(page1.status).toBe(200);
       expect(page2.status).toBe(200);
@@ -695,18 +693,15 @@ describe("POST /api/v1/posts/get", () => {
     it("should coerce page=0 or -1 to page=1", async () => {
       const page0 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 0 });
+        .send({ boardId: [board.boardId], limit: 5, page: 0 });
 
       const pageNeg1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: -1 });
+        .send({ boardId: [board.boardId], limit: 5, page: -1 });
 
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ limit: 5, page: 1 });
+        .send({ boardId: [board.boardId], limit: 5, page: 1 });
 
       const ids0 = page0.body.posts.map((p: IPost) => p.postId);
       const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
@@ -719,8 +714,7 @@ describe("POST /api/v1/posts/get", () => {
     it("should return empty posts when '?page=1000'", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId] })
-        .query({ page: 1000 });
+        .send({ boardId: [board.boardId], page: 1000 });
 
       expect(res.status).toBe(200);
       expect(res.body.posts).toHaveLength(0);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -516,8 +516,8 @@ describe("POST /api/v1/posts/get", () => {
       expect(typeof start_cursor).toBe("string");
       expect(typeof end_cursor).toBe("string");
 
-      expect(res.body.page_info.start_cursor).toBe(firstItem.slug);
-      expect(res.body.page_info.end_cursor).toBe(lastItem.slug);
+      expect(res.body.page_info.start_cursor).toBe(firstItem.postId);
+      expect(res.body.page_info.end_cursor).toBe(lastItem.postId);
 
       // total_count and total_pages should be present in cursor mode
       expect(typeof res.body.total_count).toBe("number");
@@ -533,7 +533,7 @@ describe("POST /api/v1/posts/get", () => {
       expect(firstPage.body.page_info.count).toBeLessThanOrEqual(5);
 
       const endCursor = firstPage.body.page_info.end_cursor;
-      const firstPageSlugs = firstPage.body.posts.map((p: IPost) => p.slug);
+      const firstPageId = firstPage.body.posts.map((p: IPost) => p.postId);
 
       const secondPage = await supertest(app)
         .post("/api/v1/posts/get")
@@ -548,9 +548,9 @@ describe("POST /api/v1/posts/get", () => {
       expect(secondPage.body.page_info).toBeDefined();
       expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
 
-      const page2Slugs = secondPage.body.posts.map((p: IPost) => p.slug);
+      const secondPageId = secondPage.body.posts.map((p: IPost) => p.postId);
 
-      const overlap = page2Slugs.filter((s) => firstPageSlugs.includes(s));
+      const overlap = secondPageId.filter((s) => firstPageId.includes(s));
       expect(overlap.length).toBe(0);
 
       expect(secondPage.body.page_info.current_page).toBeGreaterThanOrEqual(2);
@@ -624,7 +624,7 @@ describe("POST /api/v1/posts/get", () => {
         .get("/api/v1/posts/get")
         .query({ first: 3 });
       expect(res1.headers["content-type"]).toContain("application/json");
-      const lastId = res1.body.results[2].userId;
+      const lastId = res1.body.results[2].postId;
 
       const res2 = await supertest(app).get("/api/v1/posts/get").query({
         first: 3,
@@ -638,8 +638,8 @@ describe("POST /api/v1/posts/get", () => {
       expect(res2.body.page_info.end_cursor).toBeTypeOf("string");
       expect(res2.body.page_info.start_cursor).toBeTypeOf("string");
 
-      const ids1 = res1.body.results.map((p: IPost) => p.slug);
-      const ids2 = res2.body.results.map((p: IPost) => p.slug);
+      const ids1 = res1.body.results.map((p: IPost) => p.postId);
+      const ids2 = res2.body.results.map((p: IPost) => p.postId);
       expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
     });
   });
@@ -657,8 +657,8 @@ describe("POST /api/v1/posts/get", () => {
 
       expect(page1.body.page_info).toBeUndefined();
 
-      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
-      const ids2 = page2.body.posts.map((p: IPost) => p.slug);
+      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
+      const ids2 = page2.body.posts.map((p: IPost) => p.postId);
 
       const overlap = ids1.filter((id: string) => ids2.includes(id));
       expect(overlap.length).toBe(0);
@@ -675,9 +675,9 @@ describe("POST /api/v1/posts/get", () => {
         .post("/api/v1/posts/get")
         .send({ limit: 5, page: 1, boardId: [board.boardId] });
 
-      const ids0 = page0.body.posts.map((p: IPost) => p.slug);
-      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.slug);
-      const ids1 = page1.body.posts.map((p: IPost) => p.slug);
+      const ids0 = page0.body.posts.map((p: IPost) => p.postId);
+      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
+      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
 
       expect(ids0).toEqual(ids1);
       expect(idsNeg1).toEqual(ids1);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -111,7 +111,7 @@ describe("POST /api/v1/posts/get", () => {
     // Now request page 2 explicitly to ensure default was page 1
     const resPage2 = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ page: 2 });
+      .query({ page: 2 });
     expect(resPage2.headers["content-type"]).toContain("application/json");
     expect(resPage2.status).toBe(200);
 
@@ -356,13 +356,8 @@ describe("POST /api/v1/posts/get", () => {
 
     const asc = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({
-        boardId: [board.boardId],
-        created: "ASC",
-        limit: 10,
-        page: 1,
-        userId: "",
-      });
+      .send({ boardId: [board.boardId], userId: "" })
+      .query({ created: "ASC", limit: 10, page: 1 });
 
     expect(asc.headers["content-type"]).toContain("application/json");
     expect(asc.status).toBe(200);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -526,7 +526,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should paginate using 'after' param and increase current_page", async () => {
       const firstPage = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, created: "ASC" });
 
       expect(firstPage.status).toBe(200);
       expect(firstPage.body.page_info).toBeDefined();
@@ -537,12 +538,8 @@ describe("POST /api/v1/posts/get", () => {
 
       const secondPage = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({
-          first: 5,
-          after: endCursor,
-          created: "ASC",
-          boardId: [board.boardId],
-        });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, after: endCursor, created: "ASC" });
 
       expect(secondPage.status).toBe(200);
       expect(secondPage.body.page_info).toBeDefined();
@@ -559,7 +556,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should compute has_next_page correctly for small first value", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 3, created: "DESC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 3, created: "DESC" });
 
       expect(res.status).toBe(200);
       expect(res.body.page_info).toBeDefined();
@@ -570,7 +568,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should throw VALIDATION_ERROR for invalid 'after' param", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, after: "not-a-uuid", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, after: "not-a-uuid" });
 
       expect(res.status).toBe(400);
       expect(res.body.code).toBe("VALIDATION_ERROR");
@@ -579,10 +578,13 @@ describe("POST /api/v1/posts/get", () => {
     it("should sort posts by 'created' ASC and DESC", async () => {
       const ascRes = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, created: "ASC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, created: "ASC" });
+
       const descRes = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ first: 5, created: "DESC", boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ first: 5, created: "DESC" });
 
       expect(ascRes.status).toBe(200);
       expect(descRes.status).toBe(200);
@@ -622,14 +624,19 @@ describe("POST /api/v1/posts/get", () => {
     it("should handle cursor pagination correctly", async () => {
       const res1 = await supertest(app)
         .post("/api/v1/posts/get")
+        .send({ boardId: [board.boardId] })
         .query({ first: 3 });
+
       expect(res1.headers["content-type"]).toContain("application/json");
       const lastId = res1.body.results[2].postId;
 
-      const res2 = await supertest(app).get("/api/v1/posts/get").query({
-        first: 3,
-        after: lastId,
-      });
+      const res2 = await supertest(app)
+        .get("/api/v1/posts/get")
+        .send({ boardId: [board.boardId] })
+        .query({
+          first: 3,
+          after: lastId,
+        });
 
       expect(res2.headers["content-type"]).toContain("application/json");
       expect(res2.status).toBe(200);
@@ -670,10 +677,13 @@ describe("POST /api/v1/posts/get", () => {
     it("should support offset pagination via page param", async () => {
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 1, boardId: [board.boardId], created: "ASC" });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 1, created: "ASC" });
+
       const page2 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 2, boardId: [board.boardId], created: "ASC" });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 2, created: "ASC" });
 
       expect(page1.status).toBe(200);
       expect(page2.status).toBe(200);
@@ -687,13 +697,18 @@ describe("POST /api/v1/posts/get", () => {
     it("should coerce page=0 or -1 to page=1", async () => {
       const page0 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 0, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 0 });
+
       const pageNeg1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: -1, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: -1 });
+
       const page1 = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ limit: 5, page: 1, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ limit: 5, page: 1 });
 
       const ids0 = page0.body.posts.map((p: IPost) => p.postId);
       const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
@@ -706,7 +721,8 @@ describe("POST /api/v1/posts/get", () => {
     it("should return empty posts when '?page=1000'", async () => {
       const res = await supertest(app)
         .post("/api/v1/posts/get")
-        .send({ page: 1000, boardId: [board.boardId] });
+        .send({ boardId: [board.boardId] })
+        .query({ page: 1000 });
 
       expect(res.status).toBe(200);
       expect(res.body.posts).toHaveLength(0);

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -492,7 +492,7 @@ describe("POST /api/v1/posts/get", () => {
     });
 
     it("should default to cursor pagination return default list when no '?first=' param", async () => {
-      const res = await supertest(app).get("/api/v1/posts/get");
+      const res = await supertest(app).post("/api/v1/posts/get");
 
       const firstItem: IPost = res.body.posts[0];
       const lastItem: IPost = res.body.posts[res.body.posts.length - 1];
@@ -607,7 +607,7 @@ describe("POST /api/v1/posts/get", () => {
     });
 
     it("should handle empty '?after=' param gracefully", async () => {
-      const res = await supertest(app).get("/api/v1/posts/get").query({
+      const res = await supertest(app).post("/api/v1/posts/get").query({
         after: "",
       });
 
@@ -621,7 +621,7 @@ describe("POST /api/v1/posts/get", () => {
 
     it("should handle cursor pagination correctly", async () => {
       const res1 = await supertest(app)
-        .get("/api/v1/posts/get")
+        .post("/api/v1/posts/get")
         .query({ first: 3 });
       expect(res1.headers["content-type"]).toContain("application/json");
       const lastId = res1.body.results[2].postId;

--- a/packages/theme/src/modules/posts.ts
+++ b/packages/theme/src/modules/posts.ts
@@ -90,7 +90,6 @@ export const getPosts = async ({
   created = "DESC",
   boardId = [],
   roadmapId = undefined,
-  after = undefined,
 }: IFilterPostRequestBody): Promise<AxiosResponse<IFilterPostResponseBody>> => {
   const { authToken } = useUserStore();
 
@@ -103,7 +102,6 @@ export const getPosts = async ({
       created,
       boardId,
       roadmapId,
-      after,
     },
     headers: {
       Authorization: `Bearer ${authToken}`,

--- a/packages/theme/src/modules/posts.ts
+++ b/packages/theme/src/modules/posts.ts
@@ -90,6 +90,7 @@ export const getPosts = async ({
   created = "DESC",
   boardId = [],
   roadmapId = undefined,
+  after = undefined,
 }: IFilterPostRequestBody): Promise<AxiosResponse<IFilterPostResponseBody>> => {
   const { authToken } = useUserStore();
 
@@ -102,6 +103,7 @@ export const getPosts = async ({
       created,
       boardId,
       roadmapId,
+      after,
     },
     headers: {
       Authorization: `Bearer ${authToken}`,

--- a/packages/types/src/posts/post.ts
+++ b/packages/types/src/posts/post.ts
@@ -30,15 +30,14 @@ interface IPostInfo {
 }
 
 export interface IFilterPostRequestQueryParams extends CursorPaginationParams {
-  created?: "asc" | "desc";
+  created?: ApiSortType;
 }
 
 export interface IFilterPostRequestBody {
-  boardId: string[];
+  boardId?: string[];
   roadmapId?: string;
-  page: string;
+  page?: string;
   limit?: string;
-  created: ApiSortType;
 }
 
 export interface IFilterPostResponseBody

--- a/packages/types/src/posts/post.ts
+++ b/packages/types/src/posts/post.ts
@@ -6,6 +6,7 @@ import type {
   ApiSortType,
   CursorPaginatedResponse,
   CursorPaginationParams,
+  IApiStatus,
 } from "../common";
 
 export interface IPost extends IPostInfo {
@@ -28,7 +29,7 @@ interface IPostInfo {
   createdAt: Date;
 }
 
-export interface IFilterPostRequestBody {
+export interface IFilterPostRequestBody extends CursorPaginationParams {
   boardId: string[];
   roadmapId?: string;
   page: string;
@@ -36,7 +37,9 @@ export interface IFilterPostRequestBody {
   created: ApiSortType;
 }
 
-export interface IFilterPostResponseBody {
+export interface IFilterPostResponseBody
+  extends Partial<CursorPaginatedResponse<IPost>> {
+  status: IApiStatus;
   posts: IPost[];
 }
 

--- a/packages/types/src/posts/post.ts
+++ b/packages/types/src/posts/post.ts
@@ -29,7 +29,11 @@ interface IPostInfo {
   createdAt: Date;
 }
 
-export interface IFilterPostRequestBody extends CursorPaginationParams {
+export interface IFilterPostRequestQueryParams extends CursorPaginationParams {
+  created?: "asc" | "desc";
+}
+
+export interface IFilterPostRequestBody {
   boardId: string[];
   roadmapId?: string;
   page: string;


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post filtering now supports cursor-based pagination using `after` and `first`.
  * Responses include continuation cursors, page information, and indicators for additional results.
  * Invalid or empty cursor values are validated and reported consistently.

* **Changes**
  * Offset-based pagination remains supported, with invalid page values normalized and out-of-range pages returning empty results.
  * Sorting can be specified when retrieving filtered posts.
  * API responses now include a status field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->