### PR TITLE
posts cursor/3 split filter post controller based on license

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,7 @@ jobs:
       LOGCHIMP_MAIL_USER: test
       LOGCHIMP_MAIL_PASSWORD: test
       LOGCHIMP_MAIL_PORT: 1025
+      LOGCHIMP_LICENSE_KEY: ${{ secrets.LOGCHIMP_LICENSE_KEY }}
       SKIP_EE_TESTS: ${{ secrets.LC_SUBMODULES_TOKEN == '' && 'true' || 'false' }}
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,6 @@ jobs:
       LOGCHIMP_MAIL_USER: test
       LOGCHIMP_MAIL_PASSWORD: test
       LOGCHIMP_MAIL_PORT: 1025
-      LOGCHIMP_LICENSE_KEY: ${{ secrets.LOGCHIMP_LICENSE_KEY }}
       SKIP_EE_TESTS: ${{ secrets.LC_SUBMODULES_TOKEN == '' && 'true' || 'false' }}
 
     strategy:
@@ -220,6 +219,8 @@ jobs:
             pnpm --filter @logchimp/email-templates copy;
 
       - name: Testing
+        env:
+          LOGCHIMP_LICENSE_KEY: ${{ secrets.LOGCHIMP_LICENSE_KEY }}
         run: pnpm --filter @logchimp/api test:integration --retry 1
 
       - name: Label PR if EE tests are skipped

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -158,8 +158,10 @@ export async function filterPost(
       voterIDs.add(post.postId);
     }
 
-    const authors = await userRepository.GetUserPublicInfo([...authorIds]);
-    const votes = await voteRepository.GetVotesByPostIDs([...voterIDs], userId);
+    const [authors, votes] = await Promise.all([
+      userRepository.GetUserPublicInfo([...authorIds]),
+      voteRepository.GetVotesByPostIDs([...voterIDs], userId),
+    ]);
 
     // Enrich posts with votes
     const posts: IPost[] = [];

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -8,11 +8,6 @@ import type {
   IPost,
 } from "@logchimp/types";
 import database from "../../database";
-
-// services
-import { getVotes } from "../../services/votes/getVotes";
-
-// utils
 import {
   parseAndValidateLimit,
   parseAndValidatePage,
@@ -21,6 +16,12 @@ import {
 import logger from "../../utils/logger";
 import error from "../../errorResponse.json";
 import { GET_POSTS_FILTER_COUNT } from "../../constants";
+import { UserRepository } from "../../repository/user";
+import { VoteRepository } from "../../repository/vote";
+import { valkey } from "../../cache";
+
+const userRepository = new UserRepository(database, valkey);
+const voteRepository = new VoteRepository(database, valkey);
 
 export const querySchema = v.object({
   first: v.pipe(
@@ -149,14 +150,29 @@ export async function filterPost(
       return;
     }
 
+    const authorIds = new Set<string>();
+    const voterIDs = new Set<string>();
+
+    for (const post of response) {
+      authorIds.add(post.userId);
+      voterIDs.add(post.postId);
+    }
+
+    const authors = await userRepository.GetUserPublicInfo([...authorIds]);
+    const votes = await voteRepository.GetVotesByPostIDs([...voterIDs], userId);
+
     // Enrich posts with votes
     const posts: IPost[] = [];
     for (const post of response) {
       try {
-        const voters = await getVotes(post.postId, userId);
+        const author = authors.find((author) => author.userId === post.userId);
+        const voters = votes.get(post.postId);
+
+        post.userId = undefined;
 
         posts.push({
           ...post,
+          author,
           board: null,
           roadmap: null,
           voters,
@@ -249,6 +265,7 @@ async function buildPostsQuery({
     "postId",
     "title",
     "slug",
+    "userId",
     "contentMarkdown",
     "createdAt",
     "updatedAt",

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -122,7 +122,7 @@ export async function filterPost(
   const { page, limit } = body.output;
   const { first: _first, after, created } = query.output;
 
-  const first = page ? limit : _first;
+  const first = page ? (limit ?? _first) : _first;
   if (after && !validUUID(after)) {
     return res.status(400).json({
       code: "VALIDATION_ERROR",

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -83,6 +83,8 @@ export async function filterPost(
   >,
   res: Response<FilterPostResponseBody>,
 ) {
+  console.log("filterPost CE");
+
   if (req.body?.page || req.body?.limit) {
     logger.warn(
       "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -122,7 +122,7 @@ export async function filterPost(
   const { page, limit } = body.output;
   const { first: _first, after, created } = query.output;
 
-  const first = _first ?? limit ?? GET_POSTS_FILTER_COUNT;
+  const first = page ? limit : _first;
   if (after && !validUUID(after)) {
     return res.status(400).json({
       code: "VALIDATION_ERROR",

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -10,7 +10,6 @@ import type {
 import database from "../../database";
 
 // services
-import { getBoardById } from "../../ee/services/boards/getBoardById";
 import { getVotes } from "../../services/votes/getVotes";
 
 // utils
@@ -18,13 +17,12 @@ import {
   parseAndValidateLimit,
   parseAndValidatePage,
   validUUID,
-  validUUIDs,
 } from "../../helpers";
 import logger from "../../utils/logger";
 import error from "../../errorResponse.json";
 import { GET_POSTS_FILTER_COUNT } from "../../constants";
 
-const querySchema = v.object({
+export const querySchema = v.object({
   first: v.pipe(
     v.optional(v.string(), GET_POSTS_FILTER_COUNT.toString()),
     v.transform((value) =>
@@ -37,7 +35,7 @@ const querySchema = v.object({
   created: v.optional(v.picklist(["ASC", "DESC"]), "DESC"),
 });
 
-const bodySchema = v.object({
+export const bodySchema = v.object({
   /**
    * @deprecated Use `first` and `after` instead.
    * For backward compatibility to support offset pagination.
@@ -62,28 +60,18 @@ const bodySchema = v.object({
       ),
     ),
   ),
-  boardId: v.optional(
-    v.pipe(
-      v.array(v.string()),
-      v.transform((value) => (Array.isArray(value) ? validUUIDs(value) : [])),
-    ),
-  ),
-  roadmapId: v.optional(
-    v.pipe(
-      v.string(),
-      v.transform((value) => validUUID(value)),
-    ),
-  ),
 });
 
-const schemaQueryErrorMap = {
+export const schemaQueryErrorMap = {
   INVALID_CURSOR: error.general.invalidCursor,
   MIN_VALUE_1: error.general.minValue1,
 };
 
-const schemaBodyErrorMap = {};
+export const schemaBodyErrorMap = {};
 
-type ResponseBody = IFilterPostResponseBody | IApiErrorResponse;
+export type FilterPostResponseBody =
+  | IFilterPostResponseBody
+  | IApiErrorResponse;
 
 export async function filterPost(
   req: Request<
@@ -92,7 +80,7 @@ export async function filterPost(
     IFilterPostRequestBody,
     IFilterPostRequestQueryParams
   >,
-  res: Response<ResponseBody>,
+  res: Response<FilterPostResponseBody>,
 ) {
   if (req.body?.page || req.body?.limit) {
     logger.warn(
@@ -130,7 +118,7 @@ export async function filterPost(
     });
   }
 
-  const { page, limit, boardId, roadmapId } = body.output;
+  const { page, limit } = body.output;
   const { first: _first, after, created } = query.output;
 
   const first = _first ?? limit ?? GET_POSTS_FILTER_COUNT;
@@ -150,8 +138,6 @@ export async function filterPost(
       page,
       after,
       created,
-      boardId: boardId || [],
-      roadmapId,
     });
 
     if (page && response.length === 0) {
@@ -163,22 +149,16 @@ export async function filterPost(
       return;
     }
 
-    // Enrich posts with board, roadmap, and votes
+    // Enrich posts with votes
     const posts: IPost[] = [];
     for (const post of response) {
       try {
-        const board = await getBoardById(post.boardId);
         const voters = await getVotes(post.postId, userId);
-        const roadmap = await database
-          .select("id", "name", "url", "color")
-          .from("roadmaps")
-          .where({ id: post.roadmap_id })
-          .first();
 
         posts.push({
           ...post,
-          board,
-          roadmap,
+          board: null,
+          roadmap: null,
           voters,
         });
       } catch (err) {
@@ -205,8 +185,6 @@ export async function filterPost(
     if (!page) {
       const metadataResults = await getPostMetadata({
         after,
-        boardId,
-        roadmapId,
         created,
       });
       if (metadataResults) {
@@ -261,34 +239,20 @@ async function buildPostsQuery({
   page,
   after,
   created,
-  boardId,
-  roadmapId,
 }: {
   first: number;
   page?: number;
   after?: string;
   created: "ASC" | "DESC";
-  boardId: string[];
-  roadmapId?: string | null;
 }) {
   let queryBuilder = database("posts").select(
     "postId",
     "title",
     "slug",
-    "boardId",
-    "roadmap_id",
     "contentMarkdown",
     "createdAt",
     "updatedAt",
   );
-
-  // Apply filters
-  if (boardId.length > 0) {
-    queryBuilder = queryBuilder.whereIn("boardId", boardId);
-  }
-  if (roadmapId) {
-    queryBuilder = queryBuilder.where("roadmap_id", roadmapId);
-  }
 
   if (page) {
     queryBuilder = queryBuilder.offset(first * (page - 1));
@@ -334,37 +298,19 @@ async function buildPostsQuery({
 
 async function getPostMetadata({
   after,
-  boardId = [] as string[],
-  roadmapId,
   created = "DESC",
 }: {
   after?: string;
-  boardId?: string[];
-  roadmapId?: string | null;
   created?: "ASC" | "DESC";
 }) {
   return database.transaction(async (trx) => {
     // Total count
     const totalCountQuery = trx("posts").count("* as count");
 
-    if (boardId.length > 0) {
-      totalCountQuery.whereIn("boardId", boardId);
-    }
-    if (roadmapId) {
-      totalCountQuery.where("roadmap_id", roadmapId);
-    }
-
     const totalCountResult = await totalCountQuery.first();
 
     // Remaining results after cursor
     let remainingQuery = trx("posts").as("next");
-
-    if (boardId.length > 0) {
-      remainingQuery = remainingQuery.whereIn("boardId", boardId);
-    }
-    if (roadmapId) {
-      remainingQuery = remainingQuery.where("roadmap_id", roadmapId);
-    }
 
     if (after) {
       const cursorPost = await trx("posts")

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -83,8 +83,6 @@ export async function filterPost(
   >,
   res: Response<FilterPostResponseBody>,
 ) {
-  console.log("filterPost CE");
-
   if (req.body?.page || req.body?.limit) {
     logger.warn(
       "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",

--- a/packages/server/src/controllers/users/updateProfile.ts
+++ b/packages/server/src/controllers/users/updateProfile.ts
@@ -5,6 +5,7 @@ import database from "../../database";
 import { sanitiseName } from "../../helpers";
 import logger from "../../utils/logger";
 import error from "../../errorResponse.json";
+import * as cache from "../../cache";
 
 export async function updateProfile(req: Request, res: Response) {
   // @ts-expect-error
@@ -30,6 +31,16 @@ export async function updateProfile(req: Request, res: Response) {
         userId,
       })
       .returning(["userId", "name", "username", "email"]);
+
+    if (cache.isActive) {
+      try {
+        await cache.valkey.del(`user:public:${userId}`);
+      } catch (e) {
+        logger.error({
+          message: e,
+        });
+      }
+    }
 
     const user = users[0];
 

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -60,6 +60,8 @@ export async function filterPost(
   >,
   res: Response<FilterPostResponseBody>,
 ) {
+  console.log("filterPost CE");
+
   if (req.body?.page || req.body?.limit) {
     logger.warn(
       "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",
@@ -158,6 +160,9 @@ export async function filterPost(
     // Enrich posts with board, roadmap, and votes
     const posts: IPost[] = [];
     for (const post of response) {
+      console.log("post EE");
+      console.log(post);
+
       const author = authors.find((author) => author.userId === post.userId);
       const board = boards.find((board) => board.boardId === post.boardId);
       const roadmap = roadmaps.find(

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -23,8 +23,15 @@ import {
   schemaBodyErrorMap,
   schemaQueryErrorMap,
 } from "../../../../controllers/post/filterPost";
-import { getBoardById } from "../../../services/boards/getBoardById";
-import { getVotes } from "../../../../services/votes/getVotes";
+import { BoardRepository } from "../../../repository/board";
+import { RoadmapRepository } from "../../../repository/roadmap";
+import { VoteRepository } from "../../../../repository/vote";
+import { UserRepository } from "../../../../repository/user";
+
+const userRepository = new UserRepository(database);
+const boardRepository = new BoardRepository(database);
+const roadmapRepository = new RoadmapRepository(database);
+const voteRepository = new VoteRepository(database);
 
 const filterPostBodySchema = v.object({
   ...bodySchema.entries,
@@ -120,27 +127,40 @@ export async function filterPost(
       return;
     }
 
+    const authorIds = new Set<string>();
+    const boardIDs = new Set<string>();
+    const roadmapIDs = new Set<string>();
+    const voterIDs = new Set<string>();
+
+    for (const post of response) {
+      authorIds.add(post.userId);
+      voterIDs.add(post.postId);
+      boardIDs.add(post.boardId);
+      roadmapIDs.add(post.roadmap_id);
+    }
+
+    const authors = await userRepository.GetUserPublicInfo([...authorIds]);
+    const boards = await boardRepository.GetBoardByIDs([...boardIDs]);
+    const roadmaps = await roadmapRepository.GetRoadmapByIDs([...roadmapIDs]);
+    const votes = await voteRepository.GetVotesByPostIDs([...voterIDs], userId);
+
     // Enrich posts with board, roadmap, and votes
     const posts: IPost[] = [];
     for (const post of response) {
-      try {
-        const board = await getBoardById(post.boardId);
-        const voters = await getVotes(post.postId, userId);
-        const roadmap = await database
-          .select("id", "name", "url", "color")
-          .from("roadmaps")
-          .where({ id: post.roadmap_id })
-          .first();
+      const author = authors.find((author) => author.userId === post.userId);
+      const board = boards.find((board) => board.boardId === post.boardId);
+      const roadmap = roadmaps.find(
+        (roadmap) => roadmap.id === post.roadmap_id,
+      );
+      const voters = votes.get(post.postId);
 
-        posts.push({
-          ...post,
-          board,
-          roadmap,
-          voters,
-        });
-      } catch (err) {
-        logger.log({ level: "error", message: err });
-      }
+      posts.push({
+        ...post,
+        author: author,
+        board: board,
+        roadmap: roadmap,
+        voters: voters,
+      });
     }
 
     const postDataLength = posts.length;
@@ -232,6 +252,7 @@ async function buildPostsQuery({
     "postId",
     "title",
     "slug",
+    "userId",
     "boardId",
     "roadmap_id",
     "contentMarkdown",

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -67,7 +67,7 @@ export async function filterPost(
 
   const query = v.safeParse(filterPostQuerySchema, req.query);
   if (!query.success) {
-    return res.status(400).json({
+    res.status(400).json({
       code: "VALIDATION_ERROR",
       message: "Invalid query parameters",
       errors: query.issues.map((issue) => ({
@@ -78,11 +78,12 @@ export async function filterPost(
         code: issue.message,
       })),
     });
+    return;
   }
 
   const body = v.safeParse(filterPostBodySchema, req.body);
   if (!body.success) {
-    return res.status(400).json({
+    res.status(400).json({
       code: "VALIDATION_ERROR",
       message: "Invalid body parameters",
       errors: body.issues.map((issue) => ({
@@ -93,6 +94,7 @@ export async function filterPost(
         code: issue.message,
       })),
     });
+    return;
   }
 
   const { page, limit, boardId, roadmapId } = body.output;
@@ -100,10 +102,11 @@ export async function filterPost(
 
   const first = _first || limit;
   if (after && !validUUID(after)) {
-    return res.status(400).json({
+    res.status(400).json({
       code: "VALIDATION_ERROR",
       message: "Invalid cursor format",
     });
+    return;
   }
 
   // @ts-expect-error
@@ -156,6 +159,10 @@ export async function filterPost(
         (roadmap) => roadmap.id === post.roadmap_id,
       );
       const voters = votes.get(post.postId);
+
+      post.userId = undefined;
+      post.boardId = undefined;
+      post.roadmap_id = undefined;
 
       posts.push({
         ...post,
@@ -263,7 +270,9 @@ async function buildPostsQuery({
     "updatedAt",
   );
 
+  // console.log("build posts query:");
   // Apply filters
+  // console.log("board ID:", boardId);
   if (boardId.length > 0) {
     queryBuilder = queryBuilder.whereIn("boardId", boardId);
   }

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -1,24 +1,377 @@
 import type { Request, Response } from "express";
 import type {
   IApiErrorResponse,
+  IFilterPostRequestBody,
+  IFilterPostRequestQueryParams,
+  IPost,
   IUpdatePostRequestBody,
   TPermission,
   TUpdatePostResponseBody,
 } from "@logchimp/types";
 import * as v from "valibot";
 import database from "../../../../database";
-
-// utils
-import { validUUID } from "../../../../helpers";
+import { validUUID, validUUIDs } from "../../../../helpers";
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 import type { GetPostStatement } from "../../../../middlewares/postExists";
 import { postsQueue } from "../../../worker/tasks/posts";
 import xss from "xss";
+import {
+  bodySchema,
+  type FilterPostResponseBody,
+  querySchema as filterPostQuerySchema,
+  schemaBodyErrorMap,
+  schemaQueryErrorMap,
+} from "../../../../controllers/post/filterPost";
+import { getBoardById } from "../../../services/boards/getBoardById";
+import { getVotes } from "../../../../services/votes/getVotes";
 
-type ResponseBody = TUpdatePostResponseBody | IApiErrorResponse;
+const filterPostBodySchema = v.object({
+  ...bodySchema.entries,
+  boardId: v.optional(
+    v.pipe(
+      v.array(v.string()),
+      v.transform((value) => (Array.isArray(value) ? validUUIDs(value) : [])),
+    ),
+  ),
+  roadmapId: v.optional(
+    v.pipe(
+      v.string(),
+      v.transform((value) => validUUID(value)),
+    ),
+  ),
+});
 
-const bodySchema = v.object({
+export async function filterPost(
+  req: Request<
+    unknown,
+    unknown,
+    IFilterPostRequestBody,
+    IFilterPostRequestQueryParams
+  >,
+  res: Response<FilterPostResponseBody>,
+) {
+  if (req.body?.page || req.body?.limit) {
+    logger.warn(
+      "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",
+    );
+  }
+
+  const query = v.safeParse(filterPostQuerySchema, req.query);
+  if (!query.success) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid query parameters",
+      errors: query.issues.map((issue) => ({
+        ...issue,
+        message: schemaQueryErrorMap[issue.message]
+          ? schemaQueryErrorMap[issue.message]
+          : undefined,
+        code: issue.message,
+      })),
+    });
+  }
+
+  const body = v.safeParse(filterPostBodySchema, req.body);
+  if (!body.success) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid body parameters",
+      errors: body.issues.map((issue) => ({
+        ...issue,
+        message: schemaBodyErrorMap[issue.message]
+          ? schemaBodyErrorMap[issue.message]
+          : undefined,
+        code: issue.message,
+      })),
+    });
+  }
+
+  const { page, limit, boardId, roadmapId } = body.output;
+  const { first: _first, after, created } = query.output;
+
+  const first = _first || limit;
+  if (after && !validUUID(after)) {
+    return res.status(400).json({
+      code: "VALIDATION_ERROR",
+      message: "Invalid cursor format",
+    });
+  }
+
+  // @ts-expect-error
+  const userId: string | undefined = req.user?.userId;
+
+  try {
+    const response = await buildPostsQuery({
+      first,
+      page,
+      after,
+      created,
+      boardId: boardId || [],
+      roadmapId,
+    });
+
+    if (page && response.length === 0) {
+      res.status(200).json({
+        status: { code: 200, type: "success" },
+        posts: [],
+        results: [],
+      });
+      return;
+    }
+
+    // Enrich posts with board, roadmap, and votes
+    const posts: IPost[] = [];
+    for (const post of response) {
+      try {
+        const board = await getBoardById(post.boardId);
+        const voters = await getVotes(post.postId, userId);
+        const roadmap = await database
+          .select("id", "name", "url", "color")
+          .from("roadmaps")
+          .where({ id: post.roadmap_id })
+          .first();
+
+        posts.push({
+          ...post,
+          board,
+          roadmap,
+          voters,
+        });
+      } catch (err) {
+        logger.log({ level: "error", message: err });
+      }
+    }
+
+    const postDataLength = posts.length;
+
+    let startCursor: string | null = null;
+    let endCursor: string | null = null;
+
+    if (!page) {
+      startCursor = postDataLength > 0 ? String(posts[0].postId) : null;
+      endCursor =
+        postDataLength > 0 ? String(posts[postDataLength - 1].postId) : null;
+    }
+
+    let totalCount: number | null = null;
+    let totalPages: number | null = null;
+    let currentPage = 1;
+    let hasNextPage = false;
+
+    if (!page) {
+      const metadataResults = await getPostMetadata({
+        after,
+        boardId,
+        roadmapId,
+        created,
+      });
+      if (metadataResults) {
+        totalCount = metadataResults.totalCount;
+        totalPages = Math.ceil(metadataResults.totalCount / first);
+        hasNextPage = metadataResults.remainingResultsCount - first > 0;
+
+        if (after) {
+          const seenResults =
+            totalCount - metadataResults.remainingResultsCount;
+          currentPage = Math.floor(seenResults / first) + 1;
+        }
+      }
+    }
+
+    res.status(200).send({
+      status: {
+        code: 200,
+        type: "success",
+      },
+      posts,
+      results: posts,
+      ...(page
+        ? {}
+        : {
+            page_info: {
+              count: postDataLength,
+              current_page: currentPage,
+              has_next_page: hasNextPage,
+              end_cursor: endCursor,
+              start_cursor: startCursor,
+            },
+            total_pages: totalPages,
+            total_count: totalCount,
+          }),
+    });
+  } catch (err) {
+    logger.log({
+      level: "error",
+      message: err,
+    });
+
+    res.status(500).send({
+      message: error.general.serverError,
+      code: "SERVER_ERROR",
+    });
+  }
+}
+
+async function buildPostsQuery({
+  first,
+  page,
+  after,
+  created,
+  boardId,
+  roadmapId,
+}: {
+  first: number;
+  page?: number;
+  after?: string;
+  created: "ASC" | "DESC";
+  boardId: string[];
+  roadmapId?: string | null;
+}) {
+  let queryBuilder = database("posts").select(
+    "postId",
+    "title",
+    "slug",
+    "boardId",
+    "roadmap_id",
+    "contentMarkdown",
+    "createdAt",
+    "updatedAt",
+  );
+
+  // Apply filters
+  if (boardId.length > 0) {
+    queryBuilder = queryBuilder.whereIn("boardId", boardId);
+  }
+  if (roadmapId) {
+    queryBuilder = queryBuilder.where("roadmap_id", roadmapId);
+  }
+
+  if (page) {
+    queryBuilder = queryBuilder.offset(first * (page - 1));
+  } else if (after) {
+    // Fetch the cursor post's createdAt timestamp
+    const cursorPost = await database("posts")
+      .select("createdAt")
+      .where("postId", "=", after)
+      .first();
+
+    if (cursorPost) {
+      if (created === "DESC") {
+        queryBuilder = queryBuilder.where((builder) => {
+          builder
+            .where("createdAt", "<", cursorPost.createdAt)
+            .orWhere((subBuilder) => {
+              subBuilder
+                .where("createdAt", "=", cursorPost.createdAt)
+                .where("postId", "<", after);
+            });
+        });
+      } else {
+        queryBuilder = queryBuilder.where((builder) => {
+          builder
+            .where("createdAt", ">", cursorPost.createdAt)
+            .orWhere((subBuilder) => {
+              subBuilder
+                .where("createdAt", "=", cursorPost.createdAt)
+                .where("postId", ">", after);
+            });
+        });
+      }
+    }
+  }
+
+  queryBuilder = queryBuilder
+    .orderBy("createdAt", created)
+    .orderBy("postId", created)
+    .limit(first);
+
+  return queryBuilder;
+}
+
+async function getPostMetadata({
+  after,
+  boardId = [] as string[],
+  roadmapId,
+  created = "DESC",
+}: {
+  after?: string;
+  boardId?: string[];
+  roadmapId?: string | null;
+  created?: "ASC" | "DESC";
+}) {
+  return database.transaction(async (trx) => {
+    // Total count
+    const totalCountQuery = trx("posts").count("* as count");
+
+    if (boardId.length > 0) {
+      totalCountQuery.whereIn("boardId", boardId);
+    }
+    if (roadmapId) {
+      totalCountQuery.where("roadmap_id", roadmapId);
+    }
+
+    const totalCountResult = await totalCountQuery.first();
+
+    // Remaining results after cursor
+    let remainingQuery = trx("posts").as("next");
+
+    if (boardId.length > 0) {
+      remainingQuery = remainingQuery.whereIn("boardId", boardId);
+    }
+    if (roadmapId) {
+      remainingQuery = remainingQuery.where("roadmap_id", roadmapId);
+    }
+
+    if (after) {
+      const cursorPost = await trx("posts")
+        .select("createdAt")
+        .where("postId", "=", after)
+        .first();
+
+      if (cursorPost) {
+        if (created === "DESC") {
+          remainingQuery = remainingQuery.where((builder) => {
+            builder
+              .where("createdAt", "<", cursorPost.createdAt)
+              .orWhere((subBuilder) => {
+                subBuilder
+                  .where("createdAt", "=", cursorPost.createdAt)
+                  .where("postId", "<", after);
+              });
+          });
+        } else {
+          remainingQuery = remainingQuery.where((builder) => {
+            builder
+              .where("createdAt", ">", cursorPost.createdAt)
+              .orWhere((subBuilder) => {
+                subBuilder
+                  .where("createdAt", "=", cursorPost.createdAt)
+                  .where("postId", ">", after);
+              });
+          });
+        }
+      }
+    }
+
+    const remainingResult = await trx
+      .count("* as count")
+      .from(remainingQuery)
+      .first();
+
+    const totalCount = Number.parseInt(String(totalCountResult.count), 10);
+    const remainingResultsCount = Number.parseInt(
+      String(remainingResult.count),
+      10,
+    );
+
+    return { totalCount, remainingResultsCount };
+  });
+}
+
+type UpdatePostResponseBody = TUpdatePostResponseBody | IApiErrorResponse;
+
+const updatePostBodySchema = v.object({
   title: v.message(
     v.pipe(v.optional(v.string(), ""), v.trim(), v.nonEmpty()),
     "POST_TITLE_MISSING",
@@ -33,13 +386,13 @@ const bodySchema = v.object({
   ),
 });
 
-const schemaBodyErrorMap = {
+const updatePostSchemaBodyErrorMap = {
   POST_TITLE_MISSING: error.api.posts.titleMissing,
 };
 
 export async function updatePost(
   req: Request<unknown, unknown, IUpdatePostRequestBody>,
-  res: Response<ResponseBody>,
+  res: Response<UpdatePostResponseBody>,
 ) {
   // @ts-expect-error
   const userId = req.user.userId;
@@ -60,15 +413,15 @@ export async function updatePost(
     });
   }
 
-  const body = v.safeParse(bodySchema, req.body);
+  const body = v.safeParse(updatePostBodySchema, req.body);
   if (!body.success) {
     return res.status(400).json({
       code: "VALIDATION_ERROR",
       message: "Invalid body parameters",
       errors: body.issues.map((issue) => ({
         ...issue,
-        message: schemaBodyErrorMap[issue.message]
-          ? schemaBodyErrorMap[issue.message]
+        message: updatePostSchemaBodyErrorMap[issue.message]
+          ? updatePostSchemaBodyErrorMap[issue.message]
           : undefined,
         code: issue.message,
       })),

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -140,8 +140,12 @@ export async function filterPost(
     for (const post of response) {
       authorIds.add(post.userId);
       voterIDs.add(post.postId);
-      boardIDs.add(post.boardId);
-      roadmapIDs.add(post.roadmap_id);
+      if (post.boardId) {
+        boardIDs.add(post.boardId);
+      }
+      if (post.roadmap_id) {
+        roadmapIDs.add(post.roadmap_id);
+      }
     }
 
     const authors = await userRepository.GetUserPublicInfo([...authorIds]);

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -172,8 +172,8 @@ export async function filterPost(
       posts.push({
         ...post,
         author: author,
-        board: board,
-        roadmap: roadmap,
+        board: board ?? null,
+        roadmap: roadmap ?? null,
         voters: voters,
       });
     }

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -60,8 +60,6 @@ export async function filterPost(
   >,
   res: Response<FilterPostResponseBody>,
 ) {
-  console.log("filterPost CE");
-
   if (req.body?.page || req.body?.limit) {
     logger.warn(
       "Offset-based pagination is deprecated and will be removed in next major release. Please migrate to cursor pagination instead.",
@@ -160,9 +158,6 @@ export async function filterPost(
     // Enrich posts with board, roadmap, and votes
     const posts: IPost[] = [];
     for (const post of response) {
-      console.log("post EE");
-      console.log(post);
-
       const author = authors.find((author) => author.userId === post.userId);
       const board = boards.find((board) => board.boardId === post.boardId);
       const roadmap = roadmaps.find(

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -28,6 +28,7 @@ import { RoadmapRepository } from "../../../repository/roadmap";
 import { VoteRepository } from "../../../../repository/vote";
 import { UserRepository } from "../../../../repository/user";
 import { valkey } from "../../../../cache";
+import { GET_POSTS_FILTER_COUNT } from "../../../../constants";
 
 const userRepository = new UserRepository(database, valkey);
 const boardRepository = new BoardRepository(database, valkey);
@@ -100,7 +101,7 @@ export async function filterPost(
   const { page, limit, boardId, roadmapId } = body.output;
   const { first: _first, after, created } = query.output;
 
-  const first = _first || limit;
+  const first = _first ?? limit ?? GET_POSTS_FILTER_COUNT;
   if (after && !validUUID(after)) {
     res.status(400).json({
       code: "VALIDATION_ERROR",

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -101,7 +101,7 @@ export async function filterPost(
   const { page, limit, boardId, roadmapId } = body.output;
   const { first: _first, after, created } = query.output;
 
-  const first = page ? limit : _first;
+  const first = page ? (limit ?? _first) : _first;
   if (after && !validUUID(after)) {
     res.status(400).json({
       code: "VALIDATION_ERROR",

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -101,7 +101,7 @@ export async function filterPost(
   const { page, limit, boardId, roadmapId } = body.output;
   const { first: _first, after, created } = query.output;
 
-  const first = _first ?? limit ?? GET_POSTS_FILTER_COUNT;
+  const first = page ? limit : _first;
   if (after && !validUUID(after)) {
     res.status(400).json({
       code: "VALIDATION_ERROR",

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -28,7 +28,6 @@ import { RoadmapRepository } from "../../../repository/roadmap";
 import { VoteRepository } from "../../../../repository/vote";
 import { UserRepository } from "../../../../repository/user";
 import { valkey } from "../../../../cache";
-import { GET_POSTS_FILTER_COUNT } from "../../../../constants";
 
 const userRepository = new UserRepository(database, valkey);
 const boardRepository = new BoardRepository(database, valkey);
@@ -148,12 +147,12 @@ export async function filterPost(
       }
     }
 
-    const authors = await userRepository.GetUserPublicInfo([...authorIds]);
-    const boards = await boardRepository.GetPublicBoardByIDs([...boardIDs]);
-    const roadmaps = await roadmapRepository.GetPublicRoadmapByIDs([
-      ...roadmapIDs,
+    const [authors, boards, roadmaps, votes] = await Promise.all([
+      userRepository.GetUserPublicInfo([...authorIds]),
+      boardRepository.GetPublicBoardByIDs([...boardIDs]),
+      roadmapRepository.GetPublicRoadmapByIDs([...roadmapIDs]),
+      voteRepository.GetVotesByPostIDs([...voterIDs], userId),
     ]);
-    const votes = await voteRepository.GetVotesByPostIDs([...voterIDs], userId);
 
     // Enrich posts with board, roadmap, and votes
     const posts: IPost[] = [];

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -27,11 +27,12 @@ import { BoardRepository } from "../../../repository/board";
 import { RoadmapRepository } from "../../../repository/roadmap";
 import { VoteRepository } from "../../../../repository/vote";
 import { UserRepository } from "../../../../repository/user";
+import { valkey } from "../../../../cache";
 
-const userRepository = new UserRepository(database);
-const boardRepository = new BoardRepository(database);
-const roadmapRepository = new RoadmapRepository(database);
-const voteRepository = new VoteRepository(database);
+const userRepository = new UserRepository(database, valkey);
+const boardRepository = new BoardRepository(database, valkey);
+const roadmapRepository = new RoadmapRepository(database, valkey);
+const voteRepository = new VoteRepository(database, valkey);
 
 const filterPostBodySchema = v.object({
   ...bodySchema.entries,
@@ -140,8 +141,10 @@ export async function filterPost(
     }
 
     const authors = await userRepository.GetUserPublicInfo([...authorIds]);
-    const boards = await boardRepository.GetBoardByIDs([...boardIDs]);
-    const roadmaps = await roadmapRepository.GetRoadmapByIDs([...roadmapIDs]);
+    const boards = await boardRepository.GetPublicBoardByIDs([...boardIDs]);
+    const roadmaps = await roadmapRepository.GetPublicRoadmapByIDs([
+      ...roadmapIDs,
+    ]);
     const votes = await voteRepository.GetVotesByPostIDs([...voterIDs], userId);
 
     // Enrich posts with board, roadmap, and votes

--- a/packages/server/src/ee/controllers/v1/roadmaps/deleteById.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/deleteById.ts
@@ -11,6 +11,7 @@ import database from "../../../../database";
 import { validUUID } from "../../../../helpers";
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
+import * as cache from "../../../../cache";
 
 type ResponseBody = TDeleteRoadmapResponseBody | IApiErrorResponse;
 
@@ -36,6 +37,16 @@ export async function deleteById(
     await database.delete().from("roadmaps").where({
       id: id,
     });
+
+    if (cache.isActive) {
+      try {
+        await cache.valkey.del(`roadmap:public:${id}`);
+      } catch (e) {
+        logger.error({
+          message: e,
+        });
+      }
+    }
 
     res.sendStatus(204);
   } catch (err) {

--- a/packages/server/src/ee/controllers/v1/roadmaps/filter.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/filter.ts
@@ -59,8 +59,6 @@ export async function filter(
   req: Request<IGetRoadmapsParams>,
   res: Response<ResponseBody>,
 ) {
-  console.log("roadmap filter EE");
-
   const query = v.safeParse(querySchema, req.query);
   if (!query.success) {
     res.status(400).json({

--- a/packages/server/src/ee/controllers/v1/roadmaps/filter.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/filter.ts
@@ -59,6 +59,8 @@ export async function filter(
   req: Request<IGetRoadmapsParams>,
   res: Response<ResponseBody>,
 ) {
+  console.log("roadmap filter EE");
+
   const query = v.safeParse(querySchema, req.query);
   if (!query.success) {
     res.status(400).json({

--- a/packages/server/src/ee/controllers/v1/roadmaps/updateRoadmap.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/updateRoadmap.ts
@@ -10,6 +10,7 @@ import type {
 import * as v from "valibot";
 
 import database from "../../../../database";
+import * as cache from "../../../../cache";
 
 // utils
 import logger from "../../../../utils/logger";
@@ -112,6 +113,16 @@ export async function updateRoadmap(
         "display",
         "created_at",
       ]);
+
+    if (cache.isActive) {
+      try {
+        await cache.valkey.del(`roadmap:public:${id}`);
+      } catch (e) {
+        logger.error({
+          message: e,
+        });
+      }
+    }
 
     const roadmap = roadmaps[0];
 

--- a/packages/server/src/ee/repository/board.ts
+++ b/packages/server/src/ee/repository/board.ts
@@ -1,0 +1,17 @@
+import type { Knex } from "knex";
+import type { IBoard } from "@logchimp/types";
+
+export class BoardRepository {
+  db: Knex;
+
+  constructor(db: Knex) {
+    this.db = db;
+  }
+
+  async GetBoardByIDs(boardIds: string[]): Promise<IBoard[]> {
+    if (boardIds.length === 0) return [];
+    return this.db<IBoard>("boards")
+      .select("boardId", "name", "url", "color", "createdAt")
+      .whereIn("boardId", boardIds);
+  }
+}

--- a/packages/server/src/ee/repository/board.ts
+++ b/packages/server/src/ee/repository/board.ts
@@ -1,17 +1,29 @@
-import type { Knex } from "knex";
 import type { IBoard } from "@logchimp/types";
+import { QueryRepository } from "../../repository/query";
+import { DAY } from "../../cache/time";
 
-export class BoardRepository {
-  db: Knex;
+export class BoardRepository extends QueryRepository {
+  async GetPublicBoardByIDs(boardIds: string[]): Promise<IBoard[]> {
+    const keyPrefix = "board:public";
 
-  constructor(db: Knex) {
-    this.db = db;
-  }
-
-  async GetBoardByIDs(boardIds: string[]): Promise<IBoard[]> {
     if (boardIds.length === 0) return [];
-    return this.db<IBoard>("boards")
-      .select("boardId", "name", "url", "color", "createdAt")
-      .whereIn("boardId", boardIds);
+
+    const { results, missingIds } = await this.GetManyWithCached<IBoard>({
+      ids: boardIds,
+      keyPrefix,
+    });
+
+    const dbResults = await this.db("boards")
+      .select<IBoard[]>("boardId", "name", "url", "color", "createdAt")
+      .whereIn("boardId", missingIds);
+
+    await this.CacheMissingResults<IBoard>({
+      idField: "boardId",
+      results: dbResults,
+      keyPrefix,
+      ttlSeconds: DAY * 7,
+    });
+
+    return [...results, ...dbResults];
   }
 }

--- a/packages/server/src/ee/repository/roadmap.ts
+++ b/packages/server/src/ee/repository/roadmap.ts
@@ -1,18 +1,30 @@
-import type { Knex } from "knex";
 import type { IRoadmap, IRoadmapPrivate } from "@logchimp/types";
+import { QueryRepository } from "../../repository/query";
+import { DAY } from "../../cache/time";
 
-export class RoadmapRepository {
-  db: Knex;
+export class RoadmapRepository extends QueryRepository {
+  async GetPublicRoadmapByIDs(roadmapIds: string[]): Promise<IRoadmap[]> {
+    const keyPrefix = "roadmap:public";
 
-  constructor(db: Knex) {
-    this.db = db;
-  }
-
-  async GetRoadmapByIDs(roadmapIds: string[]): Promise<IRoadmap[]> {
     if (roadmapIds.length === 0) return [];
-    return this.db<IRoadmap[]>("roadmaps")
-      .select("id", "name", "url", "color")
-      .whereIn("id", roadmapIds);
+
+    const { results, missingIds } = await this.GetManyWithCached<IRoadmap>({
+      ids: roadmapIds,
+      keyPrefix,
+    });
+
+    const dbResults = await this.db("roadmaps")
+      .select<IRoadmap[]>("id", "name", "url", "color")
+      .whereIn("id", missingIds);
+
+    await this.CacheMissingResults<IRoadmap>({
+      idField: "id",
+      keyPrefix,
+      results: dbResults,
+      ttlSeconds: DAY * 7,
+    });
+
+    return [...results, ...dbResults];
   }
 
   GetById(id: string) {

--- a/packages/server/src/ee/repository/roadmap.ts
+++ b/packages/server/src/ee/repository/roadmap.ts
@@ -1,9 +1,24 @@
 import type { Knex } from "knex";
-import type { IRoadmapPrivate } from "@logchimp/types";
+import type { IRoadmap, IRoadmapPrivate } from "@logchimp/types";
 
-export function getById(db: Knex, id: string) {
-  return db<IRoadmapPrivate>("roadmaps")
-    .select("id", "name", "display", "url", "color", "created_at", "index")
-    .where("id", id)
-    .first();
+export class RoadmapRepository {
+  db: Knex;
+
+  constructor(db: Knex) {
+    this.db = db;
+  }
+
+  async GetRoadmapByIDs(roadmapIds: string[]): Promise<IRoadmap[]> {
+    if (roadmapIds.length === 0) return [];
+    return this.db<IRoadmap[]>("roadmaps")
+      .select("id", "name", "url", "color")
+      .whereIn("id", roadmapIds);
+  }
+
+  GetById(id: string) {
+    return this.db<IRoadmapPrivate>("roadmaps")
+      .select("id", "name", "display", "url", "color", "created_at", "index")
+      .where("id", id)
+      .first();
+  }
 }

--- a/packages/server/src/ee/routes/v1/posts.ts
+++ b/packages/server/src/ee/routes/v1/posts.ts
@@ -22,7 +22,14 @@ import { commentExists } from "../../middleware/commentExists";
 
 const router = express.Router();
 
-router.post("/posts/get", authOptional, eePost.posts.filterPost);
+router.post(
+  "/posts/get",
+  authOptional,
+  withLicenseGuard(eePost.posts.filterPost, {
+    requiredPlan: ["pro", "business", "enterprise"],
+    skipHandlerOnFailure: false,
+  }),
+);
 router.post("/posts/slug", authOptional, postExists, post.postBySlug);
 
 router.post("/posts", authRequired, post.create);

--- a/packages/server/src/ee/routes/v1/posts.ts
+++ b/packages/server/src/ee/routes/v1/posts.ts
@@ -12,7 +12,7 @@ import type {
 
 // controller
 import * as post from "../../../controllers/post";
-import * as eePost from "../../../ee/controllers/v1/posts";
+import * as eePost from "../../controllers/v1/posts";
 
 // middleware
 import { authOptional, authRequired } from "../../../middlewares/auth";
@@ -22,7 +22,7 @@ import { commentExists } from "../../middleware/commentExists";
 
 const router = express.Router();
 
-router.post("/posts/get", authOptional, post.filterPost);
+router.post("/posts/get", authOptional, eePost.posts.filterPost);
 router.post("/posts/slug", authOptional, postExists, post.postBySlug);
 
 router.post("/posts", authRequired, post.create);

--- a/packages/server/src/repository/query.ts
+++ b/packages/server/src/repository/query.ts
@@ -59,7 +59,7 @@ export class QueryRepository {
   ) {
     const { results, idField, keyPrefix, ttlSeconds } = options;
 
-    if (results.length === 0) return;
+    if (results.length === 0 || !this.cache) return;
 
     const pipeline = this.cache.pipeline();
 

--- a/packages/server/src/repository/query.ts
+++ b/packages/server/src/repository/query.ts
@@ -1,5 +1,6 @@
 import type { Knex } from "knex";
 import type Valstash from "iovalkey";
+import logger from "../utils/logger";
 
 type GetManyWithCachedOptions = {
   ids: string[];
@@ -41,15 +42,25 @@ export class QueryRepository {
     if (ids.length === 0) return { results, missingIds };
 
     const keys = ids.map((id) => `${keyPrefix}:${id}`);
-    const cached = await this.cache.mget(keys);
 
-    cached.forEach((raw, index) => {
-      if (raw) {
-        results.push(JSON.parse(raw) as T);
-      } else {
-        missingIds.push(ids[index]);
-      }
-    });
+    try {
+      const cached = await this.cache.mget(keys);
+
+      cached.forEach((raw, index) => {
+        if (raw) {
+          results.push(JSON.parse(raw) as T);
+        } else {
+          missingIds.push(ids[index]);
+        }
+      });
+    } catch (err) {
+      logger.error({
+        message: "Error fetching cached results",
+        err,
+      });
+
+      missingIds.push(...ids);
+    }
 
     return { results, missingIds };
   }
@@ -68,6 +79,13 @@ export class QueryRepository {
       pipeline.set(key, JSON.stringify(item), "EX", ttlSeconds);
     }
 
-    await pipeline.exec();
+    try {
+      await pipeline.exec();
+    } catch (err) {
+      logger.error({
+        message: "Error caching missing results",
+        err,
+      });
+    }
   }
 }

--- a/packages/server/src/repository/query.ts
+++ b/packages/server/src/repository/query.ts
@@ -1,0 +1,73 @@
+import type { Knex } from "knex";
+import type Valstash from "iovalkey";
+
+type GetManyWithCachedOptions = {
+  ids: string[];
+  keyPrefix: string;
+};
+
+type GetManyWithCachedResult<T> = {
+  results: T[];
+  missingIds: string[];
+};
+
+type CacheMissingResultsOptions<T> = {
+  idField: keyof T;
+  keyPrefix: string;
+  ttlSeconds: number;
+  results: T[];
+};
+
+export class QueryRepository {
+  db: Knex;
+  cache?: Valstash;
+
+  constructor(db: Knex, cache?: Valstash) {
+    this.db = db;
+    this.cache = cache;
+  }
+
+  protected async GetManyWithCached<T>(
+    options: GetManyWithCachedOptions,
+  ): Promise<GetManyWithCachedResult<T>> {
+    const results: T[] = [];
+    if (!this.cache) {
+      return { results, missingIds: options.ids };
+    }
+
+    const { ids, keyPrefix } = options;
+
+    const missingIds: string[] = [];
+    if (ids.length === 0) return { results, missingIds };
+
+    const keys = ids.map((id) => `${keyPrefix}:${id}`);
+    const cached = await this.cache.mget(keys);
+
+    cached.forEach((raw, index) => {
+      if (raw) {
+        results.push(JSON.parse(raw) as T);
+      } else {
+        missingIds.push(ids[index]);
+      }
+    });
+
+    return { results, missingIds };
+  }
+
+  protected async CacheMissingResults<T>(
+    options: CacheMissingResultsOptions<T>,
+  ) {
+    const { results, idField, keyPrefix, ttlSeconds } = options;
+
+    if (results.length === 0) return;
+
+    const pipeline = this.cache.pipeline();
+
+    for (const item of results) {
+      const key = `${keyPrefix}:${item[idField]}`;
+      pipeline.set(key, JSON.stringify(item), "EX", ttlSeconds);
+    }
+
+    await pipeline.exec();
+  }
+}

--- a/packages/server/src/repository/user.ts
+++ b/packages/server/src/repository/user.ts
@@ -2,20 +2,34 @@ import type { Knex } from "knex";
 import type { IPublicUserInfo, IUserInfo } from "@logchimp/types";
 import type { TCreatedUser } from "../services/auth/types";
 import database from "../database";
+import { QueryRepository } from "./query";
+import { DAY } from "../cache/time";
 
-export class UserRepository {
-  db: Knex;
-
-  constructor(db: Knex) {
-    this.db = db;
-  }
-
+export class UserRepository extends QueryRepository {
   async GetUserPublicInfo(userIds: string[]) {
+    const keyPrefix = "user:public";
+
     if (userIds.length === 0) return [];
-    return this.db
+
+    const { results, missingIds } =
+      await this.GetManyWithCached<IPublicUserInfo>({
+        keyPrefix,
+        ids: userIds,
+      });
+
+    const dbResults = await this.db
       .select<IPublicUserInfo[]>("userId", "name", "avatar", "username")
       .from("users")
-      .whereIn("userId", userIds);
+      .whereIn("userId", missingIds);
+
+    await this.CacheMissingResults<IPublicUserInfo>({
+      idField: "userId",
+      keyPrefix,
+      results: dbResults,
+      ttlSeconds: DAY * 3,
+    });
+
+    return [...results, ...dbResults];
   }
 }
 

--- a/packages/server/src/repository/user.ts
+++ b/packages/server/src/repository/user.ts
@@ -1,7 +1,23 @@
 import type { Knex } from "knex";
-import type { IUserInfo } from "@logchimp/types";
+import type { IPublicUserInfo, IUserInfo } from "@logchimp/types";
 import type { TCreatedUser } from "../services/auth/types";
 import database from "../database";
+
+export class UserRepository {
+  db: Knex;
+
+  constructor(db: Knex) {
+    this.db = db;
+  }
+
+  async GetUserPublicInfo(userIds: string[]) {
+    if (userIds.length === 0) return [];
+    return this.db
+      .select<IPublicUserInfo[]>("userId", "name", "avatar", "username")
+      .from("users")
+      .whereIn("userId", userIds);
+  }
+}
 
 export function getUserById(db: Knex, id: string) {
   return db("users")

--- a/packages/server/src/repository/vote.ts
+++ b/packages/server/src/repository/vote.ts
@@ -1,6 +1,6 @@
-import type { Knex } from "knex";
 import logger from "../utils/logger";
 import type { IPostVote } from "@logchimp/types";
+import { QueryRepository } from "./query";
 
 export interface IVoteTableColumns {
   voteId: string;
@@ -15,13 +15,7 @@ export interface IUserVoter extends IVoteTableColumns {
   avatar: string;
 }
 
-export class VoteRepository {
-  db: Knex;
-
-  constructor(db: Knex) {
-    this.db = db;
-  }
-
+export class VoteRepository extends QueryRepository {
   async GetVotesByPostIDs(
     postIds: string[],
     userId?: string,
@@ -99,9 +93,6 @@ export class VoteRepository {
       .from("votes")
       .innerJoin("users", "votes.userId", "users.userId")
       .whereIn("votes.postId", postIds);
-
-    console.log("ranked query:");
-    console.log(rankedSubquery.toQuery());
 
     return this.db
       .select<Array<IUserVoter & { rn: number }>>("*")

--- a/packages/server/src/repository/vote.ts
+++ b/packages/server/src/repository/vote.ts
@@ -45,7 +45,15 @@ export class VoteRepository extends QueryRepository {
       }
 
       for (const v of rankedVotes) {
-        votesMap.get(v.postId)?.votes.push(v);
+        votesMap.get(v.postId)?.votes.push({
+          userId: v.userId,
+          name: v.name,
+          username: v.username,
+          avatar: v.avatar,
+          createdAt: v.createdAt,
+          postId: v.postId,
+          voteId: v.voteId,
+        });
       }
 
       for (const vv of viewerVotes) {

--- a/packages/server/src/repository/vote.ts
+++ b/packages/server/src/repository/vote.ts
@@ -1,0 +1,122 @@
+import type { Knex } from "knex";
+import logger from "../utils/logger";
+import type { IPostVote } from "@logchimp/types";
+
+export interface IVoteTableColumns {
+  voteId: string;
+  postId: string;
+  userId: string;
+  createdAt: string;
+}
+
+export interface IUserVoter extends IVoteTableColumns {
+  name: string;
+  username: string;
+  avatar: string;
+}
+
+export class VoteRepository {
+  db: Knex;
+
+  constructor(db: Knex) {
+    this.db = db;
+  }
+
+  async GetVotesByPostIDs(
+    postIds: string[],
+    userId?: string,
+  ): Promise<Map<string, IPostVote>> {
+    const votesMap = new Map<string, IPostVote>();
+
+    if (postIds.length === 0) {
+      return votesMap;
+    }
+
+    for (const postId of postIds) {
+      votesMap.set(postId, { votes: [], votesCount: 0, viewerVote: undefined });
+    }
+
+    try {
+      const [counts, rankedVotes, viewerVotes] = await Promise.all([
+        this.getCounts(postIds),
+        this.getRankedVotes(postIds, 6),
+        userId ? this.getViewerVotes(postIds, userId) : Promise.resolve([]),
+      ]);
+
+      for (const c of counts) {
+        const entry = votesMap.get(c.postId);
+        if (entry) {
+          entry.votesCount = Number.parseInt(c.count, 10);
+        }
+      }
+
+      for (const v of rankedVotes) {
+        votesMap.get(v.postId)?.votes.push(v);
+      }
+
+      for (const vv of viewerVotes) {
+        const entry = votesMap.get(vv.postId);
+        if (entry) {
+          entry.viewerVote = vv;
+        }
+      }
+
+      return votesMap;
+    } catch (err) {
+      logger.log({
+        level: "error",
+        message: err,
+      });
+      return votesMap;
+    }
+  }
+
+  private async getCounts(
+    postIds: string[],
+  ): Promise<Array<{ postId: string; count: string }>> {
+    return this.db
+      .select("postId")
+      .count("voteId as count")
+      .from("votes")
+      .whereIn("postId", postIds)
+      .groupBy("postId");
+  }
+
+  private async getRankedVotes(
+    postIds: string[],
+    limitPerPost: number,
+  ): Promise<IUserVoter[]> {
+    const rankedSubquery = this.db
+      .select(
+        "votes.*",
+        "users.name",
+        "users.username",
+        "users.avatar",
+        this.db.raw(
+          'ROW_NUMBER() OVER (PARTITION BY "votes"."postId" ORDER BY "votes"."voteId") as rn',
+        ),
+      )
+      .from("votes")
+      .innerJoin("users", "votes.userId", "users.userId")
+      .whereIn("votes.postId", postIds);
+
+    console.log("ranked query:");
+    console.log(rankedSubquery.toQuery());
+
+    return this.db
+      .select<Array<IUserVoter & { rn: number }>>("*")
+      .from(rankedSubquery.as("ranked"))
+      .where("rn", "<=", limitPerPost);
+  }
+
+  private async getViewerVotes(
+    postIds: string[],
+    userId: string,
+  ): Promise<IVoteTableColumns[]> {
+    return this.db
+      .select<IVoteTableColumns[]>("*")
+      .from("votes")
+      .whereIn("postId", postIds)
+      .andWhere({ userId });
+  }
+}

--- a/packages/server/src/repository/vote.ts
+++ b/packages/server/src/repository/vote.ts
@@ -69,7 +69,8 @@ export class VoteRepository extends QueryRepository {
         level: "error",
         message: err,
       });
-      return votesMap;
+
+      throw err;
     }
   }
 

--- a/packages/server/src/services/users/getUsers.ts
+++ b/packages/server/src/services/users/getUsers.ts
@@ -1,20 +1,10 @@
-import type { ApiSortType, IPublicUserInfo, IUserInfo } from "@logchimp/types";
+import type { ApiSortType, IUserInfo } from "@logchimp/types";
 
 // database
 import database from "../../database";
 
 // utils
 import logger from "../../utils/logger";
-
-export async function getUserPublicInfo(
-  userId: string,
-): Promise<IPublicUserInfo> {
-  return database
-    .select<IPublicUserInfo>("userId", "name", "avatar", "username")
-    .from("users")
-    .where("userId", userId)
-    .first();
-}
 
 interface GetUserQueryOptions {
   first: number;

--- a/packages/server/src/services/votes/getVotes.ts
+++ b/packages/server/src/services/votes/getVotes.ts
@@ -2,7 +2,7 @@ import type { ICurrentUserVote, IUserVoter } from "@logchimp/types";
 
 import database from "../../database";
 import logger from "../../utils/logger";
-import type { IVoteTableColumns } from "./vote.service";
+import type { IVoteTableColumns } from "../../repository/vote";
 
 export async function getVotes(postId: string, userId?: string) {
   try {

--- a/packages/server/src/services/votes/vote.service.ts
+++ b/packages/server/src/services/votes/vote.service.ts
@@ -6,13 +6,7 @@ import database from "../../database";
 import logger from "../../utils/logger";
 import { ConflictError, ErrorCode, NotFoundError } from "../../utils/error";
 import error from "../../errorResponse.json";
-
-export interface IVoteTableColumns {
-  voteId: string;
-  userId: string;
-  postId: string;
-  createdAt: Date;
-}
+import type { IVoteTableColumns } from "../../repository/vote";
 
 interface GetVotesParams {
   postId: string;

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import supertest from "supertest";
 import { faker } from "@faker-js/faker";
 import { v4 as uuid } from "uuid";
@@ -15,6 +15,8 @@ import {
   vote as assignVote,
 } from "../../utils/generators";
 import { createRoleWithPermissions } from "../../utils/createRoleWithPermissions";
+import { GET_POSTS_FILTER_COUNT } from "../../../src/constants";
+import { describeEE, itEE } from "../../utils/skipEE";
 
 /**
  * Malicious/HTML-injection payloads used to verify that the post `title` and
@@ -64,64 +66,9 @@ const contentPayloads = [
   `javascript:/*--></title></style></textarea></script></xmp><svg/onload='+/"/+/onmouseover=1/+/[*/[]/+alert(1)//'>`,
   `'"--></style></script><script>alert(String.fromCharCode(88,83,83))</script>`,
 ];
-import { GET_POSTS_FILTER_COUNT } from "../../../src/constants";
 
 // Get posts with filters
-describe("POST /api/v1/posts/get", () => {
-  it("should use default page=1 and default limit when no filters are provided", async () => {
-    const { user: authUser } = await createUser({ isVerified: true });
-    const board = await generateBoard({}, true);
-    const roadmap = await generateRoadmap({}, true);
-
-    // Create 12 posts to exceed typical default [GET_POSTS_FILTER_COUNT]
-    const createdSlugs: string[] = [];
-    for (let i = 0; i < 12; i++) {
-      const p = await generatePost(
-        {
-          userId: authUser.userId,
-          boardId: board.boardId,
-          roadmapId: roadmap.id,
-        },
-        true,
-      );
-      createdSlugs.push(p.slug);
-    }
-
-    // Call with no filters and no pagination params
-    const resDefault = await supertest(app).post("/api/v1/posts/get");
-    expect(resDefault.headers["content-type"]).toContain("application/json");
-    expect(resDefault.status).toBe(200);
-
-    // Default page should be 1 => should return the newest posts first (DESC is default)
-    const slugsDefault: string[] = resDefault.body.posts.map(
-      (p: IPost) => p.slug,
-    );
-    expect(Array.isArray(resDefault.body.posts)).toBeTruthy();
-    expect(resDefault.body.posts.length).toBeGreaterThan(0);
-
-    // Verify DESC: last created slug should appear at or before index of earlier ones
-    const last = createdSlugs[createdSlugs.length - 1];
-    const first = createdSlugs[0];
-    const idxLast = slugsDefault.indexOf(last);
-    const idxFirst = slugsDefault.indexOf(first);
-    if (idxLast !== -1 && idxFirst !== -1) {
-      expect(idxLast).toBeLessThan(idxFirst);
-    }
-
-    // Now request page 2 explicitly to ensure default was page 1
-    const resPage2 = await supertest(app)
-      .post("/api/v1/posts/get")
-      .send({ page: 2 });
-    expect(resPage2.headers["content-type"]).toContain("application/json");
-    expect(resPage2.status).toBe(200);
-
-    // There should be minimal overlap between default page (1) and page 2 when many posts exist
-    const setDefault = new Set(slugsDefault);
-    const slugsPage2 = resPage2.body.posts.map((p: IPost) => p.slug);
-    const intersection = slugsPage2.filter((s: string) => setDefault.has(s));
-    expect(intersection.length).toBeLessThan(slugsPage2.length);
-  });
-
+describeEE("POST /api/v1/posts/get", () => {
   it.skip("should return empty posts array when no posts exist", async () => {
     const response = await supertest(app).post("/api/v1/posts/get").send({
       boardId: [],
@@ -133,192 +80,6 @@ describe("POST /api/v1/posts/get", () => {
 
     expect(Array.isArray(response.body.posts)).toBeTruthy();
     expect(response.body.posts).toHaveLength(0);
-  });
-
-  it("should filter posts by boardId list", async () => {
-    const boardA = await generateBoard({}, true);
-    const boardB = await generateBoard({}, true);
-    const roadmap = await generateRoadmap({}, true);
-    const { user: authUser } = await createUser();
-
-    const post1 = await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: boardA.boardId,
-        roadmapId: roadmap.id,
-      },
-      true,
-    );
-    const postA2 = await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: boardA.boardId,
-        roadmapId: roadmap.id,
-      },
-      true,
-    );
-    await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: boardB.boardId,
-        roadmapId: roadmap.id,
-      },
-      true,
-    );
-
-    const response = await supertest(app)
-      .post("/api/v1/posts/get")
-      .send({
-        boardId: [boardA.boardId],
-        userId: "",
-        limit: 10,
-        page: 1,
-      });
-
-    expect(response.headers["content-type"]).toContain("application/json");
-    expect(response.status).toBe(200);
-
-    const posts = response.body.posts;
-    expect(Array.isArray(posts)).toBeTruthy();
-    expect(posts.length).toBeGreaterThanOrEqual(2);
-
-    // All returned posts should belong to boardA
-    posts.forEach((p: IPost) => {
-      expect(p.board.boardId).toBe(boardA.boardId);
-      expect(p.board).toBeDefined();
-      expect(p.roadmap).toBeDefined();
-      expect(Array.isArray(p.voters.votes)).toBeTruthy();
-    });
-
-    const slugs = posts.map((p: IPost) => p.slug);
-    expect(slugs).toEqual(expect.arrayContaining([post1.slug, postA2.slug]));
-
-    if (cache.isActive) {
-      // should cache the boardA by ID
-      const boardACacheStr = await cache.valkey.get(
-        `board:public:${boardA.boardId}`,
-      );
-      const boardACache = JSON.parse(boardACacheStr) satisfies IBoard;
-      expect(boardA).toMatchObject(boardACache);
-
-      // should not have boardB cached
-      const boardBCache = await cache.valkey.get(
-        `board:public:${boardB.boardId}`,
-      );
-      expect(boardBCache).toBeNull();
-    }
-  });
-
-  it("should filter posts by roadmapId", async () => {
-    const board = await generateBoard({}, true);
-    const roadmapA = await generateRoadmap({}, true);
-    const roadmapB = await generateRoadmap({}, true);
-    const { user: authUser } = await createUser({ isVerified: true });
-
-    const postR1 = await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: board.boardId,
-        roadmapId: roadmapA.id,
-      },
-      true,
-    );
-    await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: board.boardId,
-        roadmapId: roadmapB.id,
-      },
-      true,
-    );
-
-    const response = await supertest(app).post("/api/v1/posts/get").send({
-      roadmapId: roadmapA.id,
-      userId: "",
-      limit: 10,
-      page: 1,
-    });
-
-    expect(response.headers["content-type"]).toContain("application/json");
-    expect(response.status).toBe(200);
-
-    const posts = response.body.posts;
-    expect(posts.length).toBeGreaterThanOrEqual(1);
-    posts.forEach((p: IPost) => {
-      expect(p.roadmap.id).toBe(roadmapA.id);
-    });
-    expect(posts.map((p: IPost) => p.slug)).toEqual(
-      expect.arrayContaining([postR1.slug]),
-    );
-  });
-
-  it("should paginate results with limit and page", async () => {
-    const board = await generateBoard({}, true);
-    const roadmap = await generateRoadmap({}, true);
-    const { user: authUser } = await createUser({ isVerified: true });
-
-    // Create 3 posts
-    const post1 = await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: board.boardId,
-        roadmapId: roadmap.id,
-      },
-      true,
-    );
-    const post2 = await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: board.boardId,
-        roadmapId: roadmap.id,
-      },
-      true,
-    );
-    const post3 = await generatePost(
-      {
-        userId: authUser.userId,
-        boardId: board.boardId,
-        roadmapId: roadmap.id,
-      },
-      true,
-    );
-
-    const page0 = await supertest(app)
-      .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "", limit: 2, page: 1 });
-    const page1 = await supertest(app)
-      .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "", limit: 2, page: 2 });
-
-    expect(page0.status).toBe(200);
-    expect(page1.status).toBe(200);
-    expect(page0.headers["content-type"]).toContain("application/json");
-    expect(page1.headers["content-type"]).toContain("application/json");
-    expect(page0.body.posts.length).toBeLessThanOrEqual(2);
-    expect(page1.body.posts.length).toBeLessThanOrEqual(2);
-
-    // Ensure no overlap between pages when there are at least 3 posts
-    const slugs0 = new Set(page0.body.posts.map((p: IPost) => p.slug));
-    const slugs1 = new Set(page1.body.posts.map((p: IPost) => p.slug));
-    const intersection = [...Array.from(slugs0)].filter((key) =>
-      slugs1.has(key),
-    );
-    expect(intersection.length).toBe(0);
-
-    // Ensure union contains created slugs
-    const union = new Set([...Array.from(slugs0), ...Array.from(slugs1)]);
-    const createdSlugs = [post1.slug, post2.slug, post3.slug];
-    const foundCount = createdSlugs.filter((s) => union.has(s)).length;
-    expect(foundCount).toBeGreaterThanOrEqual(3);
-
-    if (cache.isActive) {
-      // should cache the boardA by ID
-      const boardCacheStr = await cache.valkey.get(
-        `board:public:${board.boardId}`,
-      );
-      const boardCache = JSON.parse(boardCacheStr) satisfies IBoard;
-      expect(board).toMatchObject(boardCache);
-    }
   });
 
   it("should order posts in ASC order when specified", async () => {
@@ -354,7 +115,7 @@ describe("POST /api/v1/posts/get", () => {
 
     const asc = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], userId: "", limit: 10, page: 1 })
+      .send({ boardId: [board.boardId], userId: "", limit: "10", page: "1" })
       .query({ created: "ASC" });
 
     expect(asc.headers["content-type"]).toContain("application/json");
@@ -399,7 +160,7 @@ describe("POST /api/v1/posts/get", () => {
     const res = await supertest(app)
       .post("/api/v1/posts/get")
       .set("Authorization", `Bearer ${user.authToken}`)
-      .send({ boardId: [board.boardId], limit: 10, page: 1 });
+      .send({ boardId: [board.boardId] });
 
     expect(res.headers["content-type"]).toContain("application/json");
     expect(res.status).toBe(200);
@@ -431,7 +192,7 @@ describe("POST /api/v1/posts/get", () => {
 
     const res = await supertest(app)
       .post("/api/v1/posts/get")
-      .send({ boardId: [board.boardId], limit: 10, page: 1 });
+      .send({ boardId: [board.boardId] });
 
     expect(res.headers["content-type"]).toContain("application/json");
     expect(res.status).toBe(200);
@@ -442,7 +203,344 @@ describe("POST /api/v1/posts/get", () => {
     expect(found.voters.viewerVote).toBeUndefined();
   });
 
-  describe("Cursor Pagination", () => {
+  // Right now we can only load one type of API endpoint (CE / EE)
+  describe.skip("CE: Offset pagination", () => {
+    it("should not include posts with boards", async () => {
+      const boardA = await generateBoard({}, true);
+      const boardB = await generateBoard({}, true);
+      const roadmap = await generateRoadmap({}, true);
+      const { user: authUser } = await createUser();
+
+      const post1 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: boardA.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+      const postA2 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: boardA.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+      await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: boardB.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+
+      const response = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({
+          boardId: [boardA.boardId],
+          userId: "",
+          limit: "10",
+          page: "1",
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const posts = response.body.posts;
+      expect(Array.isArray(posts)).toBeTruthy();
+      expect(posts.length).toBeGreaterThanOrEqual(2);
+
+      posts.forEach((p: IPost) => {
+        expect(p.board).toBeNull();
+        expect(p.roadmap).toBeNull();
+        expect(Array.isArray(p.voters.votes)).toBeTruthy();
+      });
+
+      const slugs = posts.map((p: IPost) => p.slug);
+      expect(slugs).toEqual(expect.arrayContaining([post1.slug, postA2.slug]));
+    });
+  });
+
+  describeEE("EE: Offset pagination", () => {
+    itEE(
+      "should use default page=1 and default limit when no filters are provided",
+      async () => {
+        const { user: authUser } = await createUser({ isVerified: true });
+        const board = await generateBoard({}, true);
+        const roadmap = await generateRoadmap({}, true);
+
+        // Create 12 posts to exceed typical default [GET_POSTS_FILTER_COUNT]
+        const createdSlugs: string[] = [];
+        for (let i = 0; i < 12; i++) {
+          const p = await generatePost(
+            {
+              userId: authUser.userId,
+              boardId: board.boardId,
+              roadmapId: roadmap.id,
+            },
+            true,
+          );
+          createdSlugs.push(p.slug);
+        }
+
+        // Call with no filters and no pagination params
+        const resDefault = await supertest(app).post("/api/v1/posts/get");
+        expect(resDefault.headers["content-type"]).toContain(
+          "application/json",
+        );
+        expect(resDefault.status).toBe(200);
+
+        // Default page should be 1 => should return the newest posts first (DESC is default)
+        const slugsDefault: string[] = resDefault.body.posts.map(
+          (p: IPost) => p.slug,
+        );
+        expect(Array.isArray(resDefault.body.posts)).toBeTruthy();
+        expect(resDefault.body.posts.length).toBeGreaterThan(0);
+
+        // Verify DESC: last created slug should appear at or before index of earlier ones
+        const last = createdSlugs[createdSlugs.length - 1];
+        const first = createdSlugs[0];
+        const idxLast = slugsDefault.indexOf(last);
+        const idxFirst = slugsDefault.indexOf(first);
+        if (idxLast !== -1 && idxFirst !== -1) {
+          expect(idxLast).toBeLessThan(idxFirst);
+        }
+
+        // Now request page 2 explicitly to ensure default was page 1
+        const resPage2 = await supertest(app)
+          .post("/api/v1/posts/get")
+          .send({ page: "2" });
+        expect(resPage2.headers["content-type"]).toContain("application/json");
+        expect(resPage2.status).toBe(200);
+
+        // There should be minimal overlap between default page (1) and page 2 when many posts exist
+        const setDefault = new Set(slugsDefault);
+        const slugsPage2 = resPage2.body.posts.map((p: IPost) => p.slug);
+        const intersection = slugsPage2.filter((s: string) =>
+          setDefault.has(s),
+        );
+        expect(intersection.length).toBeLessThan(slugsPage2.length);
+      },
+    );
+
+    itEE("should coerce page=0 and page=-1 to page=1", async () => {
+      const page0 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ page: "0" });
+
+      const pageNeg1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ page: "-1" });
+
+      const page1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ page: "1" });
+
+      expect(page0.status).toBe(200);
+      expect(pageNeg1.status).toBe(200);
+      expect(page1.status).toBe(200);
+
+      const ids0 = page0.body.posts.map((p: IPost) => p.postId);
+      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
+      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
+
+      expect(ids0).toEqual(ids1);
+      expect(idsNeg1).toEqual(ids1);
+      expect(ids1).toEqual(ids1);
+    });
+
+    itEE("should filter posts by boardId list", async () => {
+      const boardA = await generateBoard({}, true);
+      const boardB = await generateBoard({}, true);
+      const roadmap = await generateRoadmap({}, true);
+      const { user: authUser } = await createUser();
+
+      const post1 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: boardA.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+      const postA2 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: boardA.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+      await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: boardB.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+
+      const response = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({
+          boardId: [boardA.boardId],
+          userId: "",
+          limit: "10",
+          page: "1",
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const posts = response.body.posts;
+      expect(Array.isArray(posts)).toBeTruthy();
+      expect(posts.length).toBeGreaterThanOrEqual(2);
+
+      // All returned posts should belong to boardA
+      posts.forEach((p: IPost) => {
+        expect(p.board.boardId).toBe(boardA.boardId);
+        expect(p.board).toBeDefined();
+        expect(p.roadmap).toBeDefined();
+        expect(Array.isArray(p.voters.votes)).toBeTruthy();
+      });
+
+      const slugs = posts.map((p: IPost) => p.slug);
+      expect(slugs).toEqual(expect.arrayContaining([post1.slug, postA2.slug]));
+
+      if (cache.isActive) {
+        // should cache the boardA by ID
+        const boardACacheStr = await cache.valkey.get(
+          `board:public:${boardA.boardId}`,
+        );
+        const boardACache = JSON.parse(boardACacheStr) satisfies IBoard;
+        expect(boardA).toMatchObject(boardACache);
+
+        // should not have boardB cached
+        const boardBCache = await cache.valkey.get(
+          `board:public:${boardB.boardId}`,
+        );
+        expect(boardBCache).toBeNull();
+      }
+    });
+
+    itEE("should filter posts by roadmapId", async () => {
+      const board = await generateBoard({}, true);
+      const roadmapA = await generateRoadmap({}, true);
+      const roadmapB = await generateRoadmap({}, true);
+      const { user: authUser } = await createUser({ isVerified: true });
+
+      const postR1 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmapA.id,
+        },
+        true,
+      );
+      await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmapB.id,
+        },
+        true,
+      );
+
+      const response = await supertest(app).post("/api/v1/posts/get").send({
+        roadmapId: roadmapA.id,
+        userId: "",
+        limit: "10",
+        page: "1",
+      });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const posts = response.body.posts;
+      expect(posts.length).toBeGreaterThanOrEqual(1);
+      posts.forEach((p: IPost) => {
+        expect(p.roadmap.id).toBe(roadmapA.id);
+      });
+      expect(posts.map((p: IPost) => p.slug)).toEqual(
+        expect.arrayContaining([postR1.slug]),
+      );
+    });
+
+    itEE("should paginate results with limit=2 and page", async () => {
+      const board = await generateBoard({}, true);
+      const roadmap = await generateRoadmap({}, true);
+      const { user: authUser } = await createUser({ isVerified: true });
+
+      // Create 3 posts
+      const post1 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+      const post2 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+      const post3 = await generatePost(
+        {
+          userId: authUser.userId,
+          boardId: board.boardId,
+          roadmapId: roadmap.id,
+        },
+        true,
+      );
+
+      const page0 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ boardId: [board.boardId], userId: "", limit: "2", page: "1" });
+      const page1 = await supertest(app)
+        .post("/api/v1/posts/get")
+        .send({ boardId: [board.boardId], userId: "", limit: "2", page: "2" });
+
+      expect(page0.status).toBe(200);
+      expect(page1.status).toBe(200);
+
+      expect(page0.headers["content-type"]).toContain("application/json");
+      expect(page1.headers["content-type"]).toContain("application/json");
+
+      expect(page0.body.posts.length).toBeLessThanOrEqual(2);
+      expect(page1.body.posts.length).toBeLessThanOrEqual(2);
+
+      // Ensure no overlap between pages when there are at least 3 posts
+      const slugs0 = new Set(page0.body.posts.map((p: IPost) => p.slug));
+      const slugs1 = new Set(page1.body.posts.map((p: IPost) => p.slug));
+      const intersection = [...Array.from(slugs0)].filter((key) =>
+        slugs1.has(key),
+      );
+      expect(intersection.length).toBe(0);
+
+      // Ensure union contains created slugs
+      const union = new Set([...Array.from(slugs0), ...Array.from(slugs1)]);
+      const createdSlugs = [post1.slug, post2.slug, post3.slug];
+      const foundCount = createdSlugs.filter((s) => union.has(s)).length;
+      expect(foundCount).toBeGreaterThanOrEqual(3);
+
+      if (cache.isActive) {
+        // should cache the boardA by ID
+        const boardCacheStr = await cache.valkey.get(
+          `board:public:${board.boardId}`,
+        );
+        const boardCache = JSON.parse(boardCacheStr) satisfies IBoard;
+        expect(board).toMatchObject(boardCache);
+      }
+    });
+  });
+
+  describeEE("Cursor Pagination", () => {
     let authUser: any;
     let board: any;
     let roadmap: any;
@@ -614,7 +712,7 @@ describe("POST /api/v1/posts/get", () => {
 
       expect(res.body.code).toBe("VALIDATION_ERROR");
       expect(res.body.message).toBe("Invalid query parameters");
-      expect(res.body.errors?.[0]?.message).toMatch(/invalid uuid/gi);
+      expect(res.body.errors?.[0]?.message).toMatch("Invalid cursor value");
     });
 
     it("should handle cursor pagination correctly", async () => {
@@ -644,80 +742,6 @@ describe("POST /api/v1/posts/get", () => {
       const ids1 = res1.body.results.map((p: IPost) => p.postId);
       const ids2 = res2.body.results.map((p: IPost) => p.postId);
       expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
-    });
-  });
-  describe("Offset Pagination", () => {
-    let authUser: any;
-    let board: any;
-    let roadmap: any;
-
-    beforeAll(async () => {
-      const userData = await createUser({ isVerified: true });
-      authUser = userData.user;
-      board = await generateBoard({}, true);
-      roadmap = await generateRoadmap({}, true);
-
-      // Generate 15 posts for pagination
-      for (let i = 0; i < 15; i++) {
-        await generatePost(
-          {
-            userId: authUser.userId,
-            boardId: board.boardId,
-            roadmapId: roadmap.id,
-          },
-          true,
-        );
-      }
-    });
-
-    it("should support offset pagination via page param", async () => {
-      const page1 = await supertest(app)
-        .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], limit: 5, page: 1 })
-        .query({ created: "ASC" });
-
-      const page2 = await supertest(app)
-        .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], limit: 5, page: 2 })
-        .query({ created: "ASC" });
-
-      expect(page1.status).toBe(200);
-      expect(page2.status).toBe(200);
-      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
-      const ids2 = page2.body.posts.map((p: IPost) => p.postId);
-
-      const overlap = ids1.filter((id: string) => ids2.includes(id));
-      expect(overlap.length).toBe(0);
-    });
-
-    it("should coerce page=0 or -1 to page=1", async () => {
-      const page0 = await supertest(app)
-        .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], limit: 5, page: 0 });
-
-      const pageNeg1 = await supertest(app)
-        .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], limit: 5, page: -1 });
-
-      const page1 = await supertest(app)
-        .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], limit: 5, page: 1 });
-
-      const ids0 = page0.body.posts.map((p: IPost) => p.postId);
-      const idsNeg1 = pageNeg1.body.posts.map((p: IPost) => p.postId);
-      const ids1 = page1.body.posts.map((p: IPost) => p.postId);
-
-      expect(ids0).toEqual(ids1);
-      expect(idsNeg1).toEqual(ids1);
-    });
-
-    it("should return empty posts when '?page=1000'", async () => {
-      const res = await supertest(app)
-        .post("/api/v1/posts/get")
-        .send({ boardId: [board.boardId], page: 1000 });
-
-      expect(res.status).toBe(200);
-      expect(res.body.posts).toHaveLength(0);
     });
   });
 });

--- a/packages/types/src/vote.ts
+++ b/packages/types/src/vote.ts
@@ -10,7 +10,7 @@ export interface ICurrentUserVote {
   voteId: string;
   userId: string;
   postId: string;
-  createdAt: Date;
+  createdAt: string;
 }
 
 export interface IPostVote {


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enterprise post retrieval with board and roadmap filtering, offset or cursor pagination, and detailed pagination metadata.
  - Post results now include enriched author, board, roadmap, and voting information.
  - Improved response performance through parallel data loading and caching.

- **Bug Fixes**
  - Public profile, roadmap, and board data now refresh correctly after updates or deletion.
  - Cache failures no longer prevent otherwise successful requests.
  - Invalid cursor errors now provide clearer feedback.

- **Access**
  - Enterprise post retrieval is now restricted to eligible plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->