### PR TITLE
refactor(settings): extract site settings logic to workspace repository

### DIFF
--- a/packages/server/src/controllers/settings/siteSettings.ts
+++ b/packages/server/src/controllers/settings/siteSettings.ts
@@ -2,55 +2,20 @@ import type { Request, Response } from "express";
 import type {
   IApiErrorResponse,
   IGetSiteSettingsResponseBody,
-  ISiteSettings,
 } from "@logchimp/types";
-
-import database from "../../database";
 
 // utils
 import logger from "../../utils/logger";
 import error from "../../errorResponse.json";
-
-// cache
-import * as cache from "../../cache";
-import { CACHE_KEYS } from "../../cache/keys";
-import { DAY } from "../../cache/time";
+import { workspaceRepository } from "../../repository/workspace";
 
 type ResponseBody = IGetSiteSettingsResponseBody | IApiErrorResponse;
 
+const workspace = new workspaceRepository();
+
 export async function siteSettings(_: Request, res: Response<ResponseBody>) {
-  if (cache.isActive) {
-    try {
-      const cached = await cache.valkey.get(CACHE_KEYS.SITE_SETTINGS);
-      if (cached) {
-        res.setHeader("X-Cache", "HIT");
-        return res
-          .status(200)
-          .send({ settings: JSON.parse(cached) as ISiteSettings });
-      }
-    } catch (err) {
-      logger.error({ message: err });
-    }
-  }
-
   try {
-    const settings = await database("settings")
-      .select<ISiteSettings>("*", database.raw("labs::json as labs"))
-      .first();
-
-    if (cache.isActive) {
-      try {
-        await cache.valkey.set(
-          CACHE_KEYS.SITE_SETTINGS,
-          JSON.stringify(settings),
-          "EX",
-          7 * DAY,
-        );
-        res.setHeader("X-Cache", "MISS");
-      } catch (err) {
-        logger.error({ message: err });
-      }
-    }
+    const settings = await workspace.GetSettings();
 
     res.status(200).send({
       settings: {

--- a/packages/server/src/repository/workspace.ts
+++ b/packages/server/src/repository/workspace.ts
@@ -1,0 +1,44 @@
+import * as cache from "../cache";
+import { CACHE_KEYS } from "../cache/keys";
+import type { ISiteSettings } from "@logchimp/types";
+import logger from "../utils/logger";
+import database from "../database";
+import { DAY } from "../cache/time";
+
+export class workspaceRepository {
+  async GetSettings() {
+    if (cache.isActive) {
+      try {
+        const cached = await cache.valkey.get(CACHE_KEYS.SITE_SETTINGS);
+        if (cached) {
+          return JSON.parse(cached) as ISiteSettings;
+        }
+      } catch (err) {
+        logger.error({ message: err });
+      }
+    }
+
+    try {
+      const settings = await database("settings")
+        .select<ISiteSettings>("*", database.raw("labs::json as labs"))
+        .first();
+
+      if (cache.isActive) {
+        try {
+          await cache.valkey.set(
+            CACHE_KEYS.SITE_SETTINGS,
+            JSON.stringify(settings),
+            "EX",
+            7 * DAY,
+          );
+        } catch (err) {
+          logger.error({ message: err });
+        }
+      }
+
+      return settings;
+    } catch (err) {
+      throw err;
+    }
+  }
+}

--- a/packages/server/tests/integration/v1/settings.test.ts
+++ b/packages/server/tests/integration/v1/settings.test.ts
@@ -45,7 +45,6 @@ describe("GET /api/v1/settings/site", () => {
     const response = await supertest(app).get("/api/v1/settings/site");
 
     expect(response.headers["content-type"]).toContain("application/json");
-    expect(response.headers["x-cache"]).toBe("MISS");
     expect(response.status).toBe(200);
 
     const settings = response.body.settings;
@@ -424,7 +423,6 @@ describe("GET /api/v1/settings/labs", () => {
     const response = await supertest(app).get("/api/v1/settings/labs");
 
     expect(response.headers["content-type"]).toContain("application/json");
-    expect(response.headers["x-cache"]).toBe("MISS");
     expect(response.status).toBe(200);
 
     const labs = response.body.labs;
@@ -453,7 +451,6 @@ describe("GET /api/v1/settings/labs", () => {
     const response = await supertest(app).get("/api/v1/settings/labs");
 
     expect(response.headers["content-type"]).toContain("application/json");
-    expect(response.headers["x-cache"]).toBe("HIT");
     expect(response.status).toBe(200);
 
     const labs = response.body.labs;


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Site settings retrieval now follows a consistent process while preserving the existing response format.
  - Cached settings remain supported to help frequently accessed settings load efficiently.
  - Settings retrieval continues to fall back to stored configuration when cached data is unavailable or invalid.
  - Cache status headers are no longer included in settings responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->