### PR TITLE
feat(posts): add license guard to `updatePost` endpoint in EE

### DIFF
--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -444,15 +444,16 @@ export async function updatePost(
 
   const checkPermission = permissions.includes("post:update");
   if (!checkPermission && userId !== authorId) {
-    return res.status(403).send({
+    res.status(403).send({
       message: error.api.roles.notEnoughPermission,
       code: "NOT_ENOUGH_PERMISSION",
     });
+    return;
   }
 
   const body = v.safeParse(updatePostBodySchema, req.body);
   if (!body.success) {
-    return res.status(400).json({
+    res.status(400).json({
       code: "VALIDATION_ERROR",
       message: "Invalid body parameters",
       errors: body.issues.map((issue) => ({
@@ -463,6 +464,7 @@ export async function updatePost(
         code: issue.message,
       })),
     });
+    return;
   }
 
   const id = validUUID(req.body.id);

--- a/packages/server/src/ee/routes/v1/posts.ts
+++ b/packages/server/src/ee/routes/v1/posts.ts
@@ -33,7 +33,16 @@ router.post(
 router.post("/posts/slug", authOptional, postExists, post.postBySlug);
 
 router.post("/posts", authRequired, post.create);
-router.patch("/posts", authRequired, postExists, eePost.posts.updatePost);
+router.patch(
+  "/posts",
+  authRequired,
+  // @ts-expect-error
+  postExists,
+  withLicenseGuard(eePost.posts.updatePost, {
+    requiredPlan: ["pro", "business", "enterprise"],
+    skipHandlerOnFailure: false,
+  }),
+);
 
 // votes
 router.get<IGetPostVotesRequestParams>(

--- a/packages/server/src/middlewares/postExists.ts
+++ b/packages/server/src/middlewares/postExists.ts
@@ -1,11 +1,12 @@
-import type { Request, Response, NextFunction } from "express";
+import type { NextFunction, Request, Response } from "express";
 import type {
-  IDeletePostByIdRequestBody,
-  IGetPostBySlugRequestBody,
-  IUpdatePostRequestBody,
-  IGetPostActivityRequestParam,
-  IRemoveVoteRequestBody,
   IAddVoteRequestBody,
+  IApiErrorResponse,
+  IDeletePostByIdRequestBody,
+  IGetPostActivityRequestParam,
+  IGetPostBySlugRequestBody,
+  IRemoveVoteRequestBody,
+  IUpdatePostRequestBody,
 } from "@logchimp/types";
 import database from "../database";
 
@@ -23,7 +24,7 @@ type RequestBody =
 
 export async function postExists(
   req: Request<IGetPostActivityRequestParam, unknown, RequestBody>,
-  res: Response,
+  res: Response<IApiErrorResponse>,
   next: NextFunction,
 ) {
   const { id, slug } = getPostIdentifier(req);


### PR DESCRIPTION
## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Changes**
  * Updating posts through the API now requires a Pro, Business, or Enterprise plan.
  * Requests from accounts without an eligible plan receive the appropriate access-denied response.

* **Error Handling**
  * Permission and invalid-request responses remain consistent, with no changes to status codes or response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->