### PR TITLE
feat: add license guard to auth OIDC callback EE endpoint

### DIFF
--- a/packages/server/src/ee/routes/v1/auth.ts
+++ b/packages/server/src/ee/routes/v1/auth.ts
@@ -1,14 +1,14 @@
 import express from "express";
-const router = express.Router();
-
 import * as auth from "../../../controllers/auth";
 import { mailConfigExists } from "../../../middlewares/mailConfigExists";
 import { withLicenseGuardWrapper } from "../../../middlewares/licenseGuardWrapper";
 import { domainBlacklist } from "../../middleware/domainBlacklist";
-import { userExists } from "../../../middlewares/userExists";
 import { authRequired } from "../../../middlewares/auth";
 import { validateEmailToken } from "../../../middlewares/validateEmailToken";
 import { OIDCLoginCallback } from "../../controllers/v1/auth";
+import { withLicenseGuard } from "../../do-not-remove/middleware/licenseGuard";
+
+const router = express.Router();
 
 router.get("/auth/me", authRequired, auth.me);
 
@@ -88,6 +88,12 @@ router.post(
 );
 
 router.get("/auth/oidc/login", auth.OIDCLogin);
-router.get("/auth/oidc/callback", OIDCLoginCallback);
+router.get(
+  "/auth/oidc/callback",
+  withLicenseGuard(OIDCLoginCallback, {
+    requiredPlan: ["pro", "business", "enterprise"],
+    skipHandlerOnFailure: false,
+  }),
+);
 
 export default router;


### PR DESCRIPTION
## Summary
<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated voting actions, allowing users to add or remove votes on posts.

* **Access Updates**
  * OIDC sign-in callbacks are now limited to Pro, Business, and Enterprise plans, with users receiving an access response when their plan does not qualify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->