### PR TITLE
chore(pnpm): use specific version v11.25.0 in Dockerfile

### DIFF
--- a/docker/local/server.Dockerfile
+++ b/docker/local/server.Dockerfile
@@ -9,7 +9,7 @@ COPY ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./
 ENV NODE_ENV=development
 
 RUN \
-    npm i -g pnpm && \
+    npm i -g pnpm@11.25.0 && \
     pnpm install && \
     chmod +x ./packages/server/scripts/*.sh
 

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -8,7 +8,7 @@ COPY ./packages/email-templates/package.json ./packages/email-templates/package.
 COPY ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./
 
 RUN \
-    npm i -g pnpm && \
+    npm i -g pnpm@11.25.0 && \
     pnpm install --frozen-lockfile --prod=false;
 
 COPY ./packages/types ./packages/types/
@@ -37,7 +37,7 @@ COPY --from=builder /app/packages/server/scripts ./packages/server/scripts
 COPY --from=builder /app/packages/email-templates/dist/ ./packages/server/dist/services/mail/templates
 
 RUN \
-    npm i -g pnpm && \
+    npm i -g pnpm@11.25.0 && \
     pnpm install --filter="@logchimp/api" && \
     chmod +x ./packages/server/scripts/*.sh
 

--- a/packages/theme/Dockerfile
+++ b/packages/theme/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . .
 
 RUN \
-    npm i -g pnpm && \
+    npm i -g pnpm@11.25.0 && \
     pnpm install --frozen-lockfile --prod=false && \
     pnpm --filter="@logchimp/types" exec pnpm build && \
     # TODO: use pnpm build script which does typescript check


### PR DESCRIPTION
## Summary

The [lighthouse](https://github.com/logchimp/logchimp/actions/runs/34016512909/job/101448319920) and [Playwright](https://github.com/logchimp/logchimp/actions/runs/34016514085/job/101441112747) CI workflow was failing due to pnpm.

**Error**

```
7.300 npm notice
7.300 npm notice New major version of npm available! 10.9.8 -> 12.0.2
7.300 npm notice Changelog: https://github.com/npm/cli/releases/tag/v12.0.2
7.300 npm notice To update run: npm install -g npm@12.0.2
7.300 npm notice
7.383 error: unexpected value 'false' for '--prod' found; no more were expected
7.383 
7.383 Usage: pnpm install --frozen-lockfile --prod
7.383 
7.383 For more information, try '--help'.
```

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the pnpm version used across local, server, and theme container builds.
  - Container builds now use pnpm 11.25.0 for more consistent and predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->