### PR TITLE
fix(theme/boards): handle "BOARDS_NOT_FOUND" error on missing `[GET] /v1/boards` API endpoint

### DIFF
--- a/packages/theme/src/ee/pages/boards/Index.vue
+++ b/packages/theme/src/ee/pages/boards/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    v-if="errorCode === 'LICENSE_VALIDATION_FAILED'"
-    class="text-center"
+    v-if="errorCode === 'LICENSE_VALIDATION_FAILED' || errorCode === 'BOARDS_NOT_FOUND'"
+    class="text-center text-gray-600 text-sm"
   >
     <p>
       No boards available
@@ -78,6 +78,8 @@ async function getBoards() {
 
     if (err.response?.data.code === "LICENSE_VALIDATION_FAILED") {
       errorCode.value = err.response.data.code;
+    } else if (err.response?.status === 404) {
+      errorCode.value = "BOARDS_NOT_FOUND"
     }
   }
 }

--- a/packages/theme/src/ee/pages/boards/Index.vue
+++ b/packages/theme/src/ee/pages/boards/Index.vue
@@ -79,7 +79,7 @@ async function getBoards() {
     if (err.response?.data.code === "LICENSE_VALIDATION_FAILED") {
       errorCode.value = err.response.data.code;
     } else if (err.response?.status === 404) {
-      errorCode.value = "BOARDS_NOT_FOUND"
+      errorCode.value = "BOARDS_NOT_FOUND";
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #1895

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The boards empty state now appears when boards cannot be found or license validation fails.
  - Updated the empty-state message styling for improved readability.
  - Board-not-found responses are now handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->