### PR TITLE
fix: trim leading/trailing dashes in update board controller

### DIFF
--- a/packages/server/src/ee/controllers/v1/boards/updateBoard.ts
+++ b/packages/server/src/ee/controllers/v1/boards/updateBoard.ts
@@ -15,6 +15,7 @@ import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
 import { BoardRepository } from "../../../repository/board";
 import { valkey } from "../../../../cache";
+import { sanitiseURL } from "../../../../helpers";
 
 type ResponseBody =
   | TBoardUpdateResponseBody
@@ -29,13 +30,7 @@ const bodySchema = v.object({
     "BOARD_NAME_MISSING",
   ),
   url: v.message(
-    v.pipe(
-      v.optional(v.string(), ""),
-      v.trim(),
-      v.toLowerCase(),
-      v.transform((url) => url.replace(/\W+/gi, "-")),
-      v.nonEmpty(),
-    ),
+    v.pipe(v.optional(v.string(), ""), v.transform(sanitiseURL), v.nonEmpty()),
     "BOARD_URL_MISSING",
   ),
   color: v.optional(

--- a/packages/server/src/helpers.ts
+++ b/packages/server/src/helpers.ts
@@ -99,7 +99,8 @@ const sanitiseURL = (value: string): string => {
   return value
     .trim()
     .toLocaleLowerCase()
-    .replace(/^_+|\W+|[^\w]|\s/g, "-");
+    .replace(/^_+|\W+|[^\w]|\s/g, "-")
+    .replace(/^-+|-+$/g, "");
 };
 
 /**

--- a/packages/server/src/helpers.ts
+++ b/packages/server/src/helpers.ts
@@ -98,7 +98,7 @@ const sanitiseURL = (value: string): string => {
 
   return value
     .trim()
-    .toLocaleLowerCase()
+    .toLowerCase()
     .replace(/^_+|\W+|[^\w]|\s/g, "-")
     .replace(/^-+|-+$/g, "");
 };

--- a/packages/server/tests/integration/v1/boards.spec.ts
+++ b/packages/server/tests/integration/v1/boards.spec.ts
@@ -1006,6 +1006,61 @@ describeEE("PATCH /api/v1/boards", () => {
     },
   );
 
+  function makeSlugCase(input: string, expected: string) {
+    const base = faker.string.alphanumeric(8).toLowerCase();
+    const exp = expected === "" ? base : `${base}-${expected}`;
+    return {
+      url: `${base} ${input}`,
+      expected: exp,
+    };
+  }
+
+  const slugUpdateCases = [
+    makeSlugCase("feature-requests", "feature-requests"),
+    makeSlugCase("Feature Requests", "feature-requests"),
+    makeSlugCase("board name with spaces", "board-name-with-spaces"),
+    makeSlugCase("board+with+plus", "board-with-plus"),
+    makeSlugCase("board#with#hash", "board-with-hash"),
+    makeSlugCase("a@@@@@@@@", "a"),
+    makeSlugCase("बोर्ड", ""),
+    makeSlugCase("😀️😈️", ""),
+    makeSlugCase("...", ""),
+    makeSlugCase("../...", ""),
+    makeSlugCase("Hello World!!!", "hello-world"),
+    makeSlugCase("  multiple   spaces  ", "multiple-spaces"),
+    makeSlugCase("UPPERCASE-SLUG", "uppercase-slug"),
+  ];
+
+  itEE.each(slugUpdateCases)(
+    "should update board url to '$url' → '$expected'",
+    async ({ url, expected }) => {
+      const board = await generateBoards({}, true);
+      const { user: authUser } = await createUser();
+      await createRoleWithPermissions(authUser.userId, ["board:update"], {
+        roleName: "Board Patcher",
+      });
+
+      const response = await supertest(app)
+        .patch("/api/v1/boards")
+        .set("Authorization", `Bearer ${authUser.authToken}`)
+        .send({
+          boardId: board.boardId,
+          name: board.name,
+          url,
+          color: board.color,
+          view_voters: board.view_voters,
+          display: board.display,
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const updated = response.body.board;
+      expect(updated.boardId).toBe(board.boardId);
+      expect(updated.url).toBe(expected);
+    },
+  );
+
   itEE("should UPDATE board", async () => {
     const board: BoardInsertRecord = await generateBoards({}, true);
     const newBoard: BoardInsertRecord = await generateBoards({}, false);

--- a/packages/server/tests/integration/v1/boards.spec.ts
+++ b/packages/server/tests/integration/v1/boards.spec.ts
@@ -1093,6 +1093,31 @@ describeEE("PATCH /api/v1/boards", () => {
     expect(responseBoard.view_voters).toBe(newBoard.view_voters);
     expect(responseBoard.display).toBe(newBoard.display);
   });
+
+  itEE("should trim leading dashes from the updated board url", async () => {
+    const base = faker.string.alphanumeric(8).toLowerCase();
+    const board = await generateBoards({}, true);
+    const { user: authUser } = await createUser();
+
+    await createRoleWithPermissions(authUser.userId, ["board:update"], {
+      roleName: "Board Patcher",
+    });
+
+    const response = await supertest(app)
+      .patch("/api/v1/boards")
+      .set("Authorization", `Bearer ${authUser.authToken}`)
+      .send({
+        boardId: board.boardId,
+        name: board.name,
+        url: `---${base}`,
+        color: board.color,
+        view_voters: board.view_voters,
+        display: board.display,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.board.url).toBe(base);
+  });
 });
 
 // Delete boards by id


### PR DESCRIPTION
## Summary


<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Board URLs are now consistently normalized when updated, including removal of unnecessary leading and trailing hyphens.
  - Improved handling of spaces, capitalization, special characters, and Unicode in board URLs.
  - Empty or symbol-only URL inputs now produce clean, predictable results.

- **Tests**
  - Added coverage for board URL normalization across a range of input formats, including uppercase text, spaces, symbols, Unicode characters, and leading hyphens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->