### PR TITLE
fix: trim leading/trailing dashes in update roadmap controller

### DIFF
--- a/packages/server/src/ee/controllers/v1/roadmaps/updateRoadmap.ts
+++ b/packages/server/src/ee/controllers/v1/roadmaps/updateRoadmap.ts
@@ -15,6 +15,7 @@ import * as cache from "../../../../cache";
 // utils
 import logger from "../../../../utils/logger";
 import error from "../../../../errorResponse.json";
+import { sanitiseURL } from "../../../../helpers";
 
 type ResponseBody =
   | TUpdateRoadmapResponseBody
@@ -27,13 +28,7 @@ const bodySchema = v.object({
     "ROADMAP_NAME_MISSING",
   ),
   url: v.message(
-    v.pipe(
-      v.optional(v.string(), ""),
-      v.trim(),
-      v.toLowerCase(),
-      v.transform((url) => url.replace(/\W+/gi, "-")),
-      v.nonEmpty(),
-    ),
+    v.pipe(v.optional(v.string(), ""), v.transform(sanitiseURL), v.nonEmpty()),
     "ROADMAP_URL_MISSING",
   ),
   color: v.optional(

--- a/packages/server/tests/integration/v1/roadmaps.spec.ts
+++ b/packages/server/tests/integration/v1/roadmaps.spec.ts
@@ -984,6 +984,30 @@ describeEE("PATCH /api/v1/roadmaps", () => {
     expect(roadmap.index).toBe(r1.index);
     expect(roadmap.created_at).toBe(r1.created_at);
   });
+
+  itEE("should trim leading dashes from the updated roadmap url", async () => {
+    const base = faker.string.alphanumeric(8).toLowerCase();
+    const roadmap = await generateRoadmap({}, true);
+    const { user: authUser } = await createUser();
+
+    await createRoleWithPermissions(authUser.userId, ["roadmap:update"], {
+      roleName: "roadmap Patcher",
+    });
+
+    const response = await supertest(app)
+      .patch("/api/v1/roadmaps")
+      .set("Authorization", `Bearer ${authUser.authToken}`)
+      .send({
+        id: roadmap.id,
+        name: roadmap.name,
+        url: `---${base}`,
+        color: roadmap.color,
+        display: roadmap.display,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.roadmap.url).toBe(base);
+  });
 });
 
 // Delete roadmaps

--- a/packages/server/tests/integration/v1/roadmaps.spec.ts
+++ b/packages/server/tests/integration/v1/roadmaps.spec.ts
@@ -898,6 +898,60 @@ describeEE("PATCH /api/v1/roadmaps", () => {
     );
   });
 
+  function makeSlugCase(input: string, expected: string) {
+    const base = faker.string.alphanumeric(8).toLowerCase();
+    const exp = expected === "" ? base : `${base}-${expected}`;
+    return {
+      url: `${base} ${input}`,
+      expected: exp,
+    };
+  }
+
+  const slugUpdateCases = [
+    makeSlugCase("feature-requests", "feature-requests"),
+    makeSlugCase("Feature Requests", "feature-requests"),
+    makeSlugCase("roadmap name with spaces", "roadmap-name-with-spaces"),
+    makeSlugCase("roadmap+with+plus", "roadmap-with-plus"),
+    makeSlugCase("roadmap#with#hash", "roadmap-with-hash"),
+    makeSlugCase("a@@@@@@@@", "a"),
+    makeSlugCase("बोर्ड", ""),
+    makeSlugCase("😀️😈️", ""),
+    makeSlugCase("...", ""),
+    makeSlugCase("../...", ""),
+    makeSlugCase("Hello World!!!", "hello-world"),
+    makeSlugCase("  multiple   spaces  ", "multiple-spaces"),
+    makeSlugCase("UPPERCASE-SLUG", "uppercase-slug"),
+  ];
+
+  itEE.each(slugUpdateCases)(
+    "should update roadmap url to '$url' → '$expected'",
+    async ({ url, expected }) => {
+      const roadmap = await generateRoadmap({}, true);
+      const { user: authUser } = await createUser();
+      await createRoleWithPermissions(authUser.userId, ["roadmap:update"], {
+        roleName: "Roadmap Patcher",
+      });
+
+      const response = await supertest(app)
+        .patch("/api/v1/roadmaps")
+        .set("Authorization", `Bearer ${authUser.authToken}`)
+        .send({
+          id: roadmap.id,
+          name: roadmap.name,
+          url,
+          color: roadmap.color,
+          display: roadmap.display,
+        });
+
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.status).toBe(200);
+
+      const updated = response.body.roadmap;
+      expect(updated.id).toBe(roadmap.id);
+      expect(updated.url).toBe(expected);
+    },
+  );
+
   itEE("should update roadmap", async () => {
     const { user } = await createUser({
       isVerified: true,


### PR DESCRIPTION
## Summary

<!-- A clear and concise description of what the PR is about. -->

## Type(s) of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Related Issues (Optional)
<!-- Link any related issues or tickets. -->
Closes #{ISSUE_NUMBER}

## Changes Made
<!-- List the key changes in this PR. -->

## Screenshot(s) / Screen Recording(s) (Optional)
<!-- If applicable, add screenshots or a short screen recording. Mandatory for UI changes (Before and After). -->

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests

## Checklist
- [ ] I have read and complied with [AI Policy](https://github.com/logchimp/logchimp/blob/master/AI_POLICY.md).
- [ ] My code follows the [Contributing Guidelines](https://github.com/logchimp/logchimp/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated relevant documentation for the respective change(s) made in this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Roadmap URLs are now sanitized consistently during updates, including spaces, punctuation, casing, Unicode characters, repeated whitespace, and leading dashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->