### PR TITLE
feat: add support for post title search in filter post endpoint

### DIFF
--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -37,6 +37,7 @@ export const querySchema = v.object({
 });
 
 export const bodySchema = v.object({
+  query: v.optional(v.pipe(v.string(), v.trim(), v.toLowerCase())),
   /**
    * @deprecated Use `first` and `after` instead.
    * For backward compatibility to support offset pagination.
@@ -119,7 +120,7 @@ export async function filterPost(
     });
   }
 
-  const { page, limit } = body.output;
+  const { page, limit, query: searchQuery } = body.output;
   const { first: _first, after, created } = query.output;
 
   const first = page ? (limit ?? _first) : _first;
@@ -133,12 +134,15 @@ export async function filterPost(
   // @ts-expect-error
   const userId: string | undefined = req.user?.userId;
 
+  const escapedQuery = searchQuery.replace(/[\\%_]/g, "\\$&");
+
   try {
     const response = await buildPostsQuery({
       first,
       page,
       after,
       created,
+      query: escapedQuery,
     });
 
     if (page && response.length === 0) {
@@ -257,11 +261,13 @@ async function buildPostsQuery({
   page,
   after,
   created,
+  query = "",
 }: {
   first: number;
   page?: number;
   after?: string;
   created: "ASC" | "DESC";
+  query?: string;
 }) {
   let queryBuilder = database("posts").select(
     "postId",
@@ -272,6 +278,11 @@ async function buildPostsQuery({
     "createdAt",
     "updatedAt",
   );
+
+  // Apply filters
+  if (query.length > 0) {
+    queryBuilder = queryBuilder.where("title", "ILIKE", `%${query}%`);
+  }
 
   if (page) {
     queryBuilder = queryBuilder.offset(first * (page - 1));
@@ -317,19 +328,29 @@ async function buildPostsQuery({
 
 async function getPostMetadata({
   after,
+  query = "",
   created = "DESC",
 }: {
   after?: string;
+  query?: string;
   created?: "ASC" | "DESC";
 }) {
   return database.transaction(async (trx) => {
     // Total count
     const totalCountQuery = trx("posts").count("* as count");
 
+    if (query.length > 0) {
+      totalCountQuery.where("title", "ILIKE", `%${query}%`);
+    }
+
     const totalCountResult = await totalCountQuery.first();
 
     // Remaining results after cursor
     let remainingQuery = trx("posts").as("next");
+
+    if (query.length > 0) {
+      remainingQuery = remainingQuery.where("title", "ILIKE", `%${query}%`);
+    }
 
     if (after) {
       const cursorPost = await trx("posts")

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -206,6 +206,7 @@ export async function filterPost(
 
     if (!page) {
       const metadataResults = await getPostMetadata({
+        query: escapedQuery,
         after,
         created,
       });

--- a/packages/server/src/controllers/post/filterPost.ts
+++ b/packages/server/src/controllers/post/filterPost.ts
@@ -134,7 +134,7 @@ export async function filterPost(
   // @ts-expect-error
   const userId: string | undefined = req.user?.userId;
 
-  const escapedQuery = searchQuery.replace(/[\\%_]/g, "\\$&");
+  const escapedQuery = (searchQuery || "").replace(/[\\%_]/g, "\\$&");
 
   try {
     const response = await buildPostsQuery({

--- a/packages/server/src/ee/controllers/v1/posts/posts.ts
+++ b/packages/server/src/ee/controllers/v1/posts/posts.ts
@@ -97,7 +97,7 @@ export async function filterPost(
     return;
   }
 
-  const { page, limit, boardId, roadmapId } = body.output;
+  const { page, limit, boardId, roadmapId, query: searchQuery } = body.output;
   const { first: _first, after, created } = query.output;
 
   const first = page ? (limit ?? _first) : _first;
@@ -112,6 +112,8 @@ export async function filterPost(
   // @ts-expect-error
   const userId: string | undefined = req.user?.userId;
 
+  const escapedQuery = (searchQuery || "").replace(/[\\%_]/g, "\\$&");
+
   try {
     const response = await buildPostsQuery({
       first,
@@ -120,6 +122,7 @@ export async function filterPost(
       created,
       boardId: boardId || [],
       roadmapId,
+      query: escapedQuery,
     });
 
     if (page && response.length === 0) {
@@ -196,6 +199,7 @@ export async function filterPost(
     if (!page) {
       const metadataResults = await getPostMetadata({
         after,
+        query: escapedQuery,
         boardId,
         roadmapId,
         created,
@@ -254,6 +258,7 @@ async function buildPostsQuery({
   created,
   boardId,
   roadmapId,
+  query = "",
 }: {
   first: number;
   page?: number;
@@ -261,6 +266,7 @@ async function buildPostsQuery({
   created: "ASC" | "DESC";
   boardId: string[];
   roadmapId?: string | null;
+  query?: string;
 }) {
   let queryBuilder = database("posts").select(
     "postId",
@@ -274,9 +280,10 @@ async function buildPostsQuery({
     "updatedAt",
   );
 
-  // console.log("build posts query:");
   // Apply filters
-  // console.log("board ID:", boardId);
+  if (query.length > 0) {
+    queryBuilder = queryBuilder.where("title", "ILIKE", `%${query}%`);
+  }
   if (boardId.length > 0) {
     queryBuilder = queryBuilder.whereIn("boardId", boardId);
   }
@@ -328,11 +335,13 @@ async function buildPostsQuery({
 
 async function getPostMetadata({
   after,
+  query = "",
   boardId = [] as string[],
   roadmapId,
   created = "DESC",
 }: {
   after?: string;
+  query?: string;
   boardId?: string[];
   roadmapId?: string | null;
   created?: "ASC" | "DESC";
@@ -341,6 +350,9 @@ async function getPostMetadata({
     // Total count
     const totalCountQuery = trx("posts").count("* as count");
 
+    if (query.length > 0) {
+      totalCountQuery.where("title", "ILIKE", `%${query}%`);
+    }
     if (boardId.length > 0) {
       totalCountQuery.whereIn("boardId", boardId);
     }
@@ -353,6 +365,9 @@ async function getPostMetadata({
     // Remaining results after cursor
     let remainingQuery = trx("posts").as("next");
 
+    if (query.length > 0) {
+      remainingQuery = remainingQuery.where("title", "ILIKE", `%${query}%`);
+    }
     if (boardId.length > 0) {
       remainingQuery = remainingQuery.whereIn("boardId", boardId);
     }

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -783,6 +783,7 @@ describeEE("POST /api/v1/posts/get", () => {
       { title: "Hello World!!!", searchTerm: "!" },
       { title: "a@@@@@@@@", searchTerm: "a@@" },
       { title: "completion 100% ready", searchTerm: "100%" },
+      { title: "percentage", searchTerm: "%" },
       { title: "post_with_underscore", searchTerm: "_" },
       { title: "post\\with\\backslash", searchTerm: "\\" },
       { title: "Mixed Case Search", searchTerm: "mIxEd cAsE" },
@@ -791,29 +792,33 @@ describeEE("POST /api/v1/posts/get", () => {
     itEE.each(searchCases)(
       "should find post named $title when searching for $searchTerm",
       async ({ title, searchTerm }) => {
+        const unique = faker.string.alphanumeric(10);
+
         const { user: authUser } = await createUser();
 
         const post = await generatePost(
           {
-            title,
+            title: `${title} ${searchTerm}${unique}`,
             userId: authUser.userId,
           },
           true,
         );
         const nonMatchingPost = await generatePost(
-          { title: "unrelated", userId: authUser.userId },
+          { title: `unrelated ${unique}`, userId: authUser.userId },
           true,
         );
 
-        const response = await supertest(app).post(`/api/v1/posts/get`).send({
-          query: searchTerm,
-        });
+        const response = await supertest(app)
+          .post(`/api/v1/posts/get`)
+          .send({
+            query: `${searchTerm}${unique}`,
+          });
 
         expect(response.headers["content-type"]).toContain("application/json");
         expect(response.status).toBe(200);
 
         const posts = response.body.posts;
-        expect(posts.length).toBeGreaterThanOrEqual(1);
+        expect(posts.length).toBe(1);
         expect(posts.map((p: IPost) => p.postId)).not.toContain(
           nonMatchingPost.postId,
         );

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -745,6 +745,90 @@ describeEE("POST /api/v1/posts/get", () => {
       expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
     });
   });
+
+  describeEE("Search by title", () => {
+    const zeroSearchResultsArr = [
+      "POST_NOT_FOUND",
+      "undefined",
+      "null",
+      "456575634",
+      "post name with spaces",
+      "post+with+plus",
+      "post#with#hash",
+      "a@@@@@@@@",
+      "*&^(*&$%&*^&%&^%*",
+    ];
+
+    itEE.each(zeroSearchResultsArr)(
+      `should return 0 search results for '%s' posts`,
+      async (name) => {
+        const response = await supertest(app)
+          .post(`/api/v1/posts/get`)
+          .send({
+            query: `${name}-${faker.string.alphanumeric(8)}`,
+          });
+
+        expect(response.headers["content-type"]).toContain("application/json");
+        expect(response.status).toBe(200);
+        expect(response.body.posts).toHaveLength(0);
+      },
+    );
+
+    const searchCases = [
+      { title: "emoji post 🚀", searchTerm: "emoji" },
+      { title: "emoji post 🚀", searchTerm: "🚀" },
+      { title: "unicode बोर्ड", searchTerm: "बोर्ड" },
+      { title: "post with spaces", searchTerm: "with spaces" },
+      { title: "post+with+plus", searchTerm: "+" },
+      { title: "post#with#hash", searchTerm: "#" },
+      { title: "Hello World!!!", searchTerm: "!" },
+      { title: "a@@@@@@@@", searchTerm: "a@@" },
+      { title: "completion 100% ready", searchTerm: "100%" },
+      { title: "post_with_underscore", searchTerm: "_" },
+      { title: "post\\with\\backslash", searchTerm: "\\" },
+    ];
+
+    itEE.each(searchCases)(
+      "should find post named '$title' when searching for '$searchTerm'",
+      async ({ title, searchTerm }) => {
+        const { user: authUser } = await createUser();
+
+        const post = await generatePost(
+          {
+            title,
+            userId: authUser.userId,
+          },
+          true,
+        );
+        const nonMatchingPost = await generatePost(
+          { title: "unrelated", userId: authUser.userId },
+          true,
+        );
+
+        const response = await supertest(app).post(`/api/v1/posts/get`).send({
+          query: searchTerm,
+        });
+
+        expect(response.headers["content-type"]).toContain("application/json");
+        expect(response.status).toBe(200);
+
+        const posts = response.body.posts;
+        expect(posts.length).toBeGreaterThanOrEqual(1);
+        expect(posts.map((p: IPost) => p.postId)).not.toContain(
+          nonMatchingPost.postId,
+        );
+
+        expect(posts).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              postId: post.postId,
+              title: post.title,
+            }),
+          ]),
+        );
+      },
+    );
+  });
 });
 
 // Create new posts

--- a/packages/server/tests/integration/v1/posts.spec.ts
+++ b/packages/server/tests/integration/v1/posts.spec.ts
@@ -775,7 +775,6 @@ describeEE("POST /api/v1/posts/get", () => {
     );
 
     const searchCases = [
-      { title: "emoji post 🚀", searchTerm: "emoji" },
       { title: "emoji post 🚀", searchTerm: "🚀" },
       { title: "unicode बोर्ड", searchTerm: "बोर्ड" },
       { title: "post with spaces", searchTerm: "with spaces" },
@@ -786,10 +785,11 @@ describeEE("POST /api/v1/posts/get", () => {
       { title: "completion 100% ready", searchTerm: "100%" },
       { title: "post_with_underscore", searchTerm: "_" },
       { title: "post\\with\\backslash", searchTerm: "\\" },
+      { title: "Mixed Case Search", searchTerm: "mIxEd cAsE" },
     ];
 
     itEE.each(searchCases)(
-      "should find post named '$title' when searching for '$searchTerm'",
+      "should find post named $title when searching for $searchTerm",
       async ({ title, searchTerm }) => {
         const { user: authUser } = await createUser();
 
@@ -826,6 +826,11 @@ describeEE("POST /api/v1/posts/get", () => {
             }),
           ]),
         );
+
+        expect(response.body.total_count).toBe(1);
+        expect(response.body.total_pages).toBe(1);
+        expect(response.body.page_info.count).toBe(1);
+        expect(response.body.page_info.has_next_page).toBe(false);
       },
     );
   });

--- a/packages/server/tests/utils/generators.ts
+++ b/packages/server/tests/utils/generators.ts
@@ -77,7 +77,7 @@ interface PostArgs {
 }
 
 const post = async (post: PostArgs, insertToDb = false) => {
-  const title = faker.commerce.productName();
+  const title = post?.title ?? faker.commerce.productName();
   const contentMarkdown = post?.contentMarkdown || faker.lorem.text();
 
   // generate slug unique identification

--- a/packages/theme/src/modules/posts.ts
+++ b/packages/theme/src/modules/posts.ts
@@ -1,5 +1,5 @@
 // packages
-import axios, { type AxiosResponse } from "axios";
+import axios, { type AxiosRequestConfig, type AxiosResponse } from "axios";
 import type {
   ICreatePostRequestBody,
   ICreatePostResponseBody,
@@ -26,11 +26,13 @@ export class Posts extends APIService {
    * Get posts
    * @param body
    * @param query
+   * @param config
    * @returns {Promise<AxiosResponse<IFilterPostResponseBody>>} response
    */
   async GetPosts(
     body: IFilterPostRequestBody,
     query?: IFilterPostRequestQueryParams,
+    config: AxiosRequestConfig = {},
   ): Promise<IFilterPostResponseBody> {
     const searchParams = new URLSearchParams();
     for (const queryKey in query) {
@@ -42,12 +44,16 @@ export class Posts extends APIService {
 
     const url = `/v1/posts/get?${searchParams.toString()}`;
 
-    return this.post(url.toString(), {
-      query: body.query,
-      page: body.page,
-      boardId: body.boardId,
-      roadmapId: body.roadmapId,
-    })
+    return this.post(
+      url.toString(),
+      {
+        query: body.query,
+        page: body.page,
+        boardId: body.boardId,
+        roadmapId: body.roadmapId,
+      },
+      config,
+    )
       .then((response) => response?.data)
       .catch((error) => {
         throw error;

--- a/packages/theme/src/modules/posts.ts
+++ b/packages/theme/src/modules/posts.ts
@@ -43,6 +43,7 @@ export class Posts extends APIService {
     const url = `/v1/posts/get?${searchParams.toString()}`;
 
     return this.post(url.toString(), {
+      query: body.query,
       page: body.page,
       boardId: body.boardId,
       roadmapId: body.roadmapId,

--- a/packages/theme/src/pages/dashboard/posts/Index.vue
+++ b/packages/theme/src/pages/dashboard/posts/Index.vue
@@ -22,6 +22,12 @@
       resource-type="posts"
     />
     <template v-else>
+      <l-text
+        v-model="dashboardPosts.searchQuery"
+        label="Search posts"
+        placeholder="Search posts by title"
+      />
+
       <post-item
         v-for="post in dashboardPosts.posts"
         :key="post.postId"
@@ -55,6 +61,7 @@ import Breadcrumbs from "../../../components/Breadcrumbs.vue";
 import BreadcrumbItem from "../../../components/ui/breadcrumbs/BreadcrumbItem.vue";
 import Button from "../../../components/ui/Button.vue";
 import LicenseValidationFailed from "../../../components/LicenseValidationFailed.vue";
+import LText from "../../../components/ui/input/LText.vue";
 
 const { permissions } = useUserStore();
 const dashboardPosts = useDashboardPosts();

--- a/packages/theme/src/store/dashboard/posts.ts
+++ b/packages/theme/src/store/dashboard/posts.ts
@@ -19,6 +19,8 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
   let abortController: AbortController | null = null;
 
   async function fetchPosts() {
+    if (state.value === "LOADING" || state.value === "COMPLETED") return;
+
     abortController?.abort();
     abortController = new AbortController();
 
@@ -105,7 +107,8 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
 
   watch(
     () => searchQuery.value,
-    async () => {
+    async (newValue, oldValue) => {
+      if (newValue === oldValue) return;
       abortController?.abort();
       state.value = "IDLE";
 

--- a/packages/theme/src/store/dashboard/posts.ts
+++ b/packages/theme/src/store/dashboard/posts.ts
@@ -1,5 +1,6 @@
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { defineStore } from "pinia";
+import { useDebounceFn } from "@vueuse/core";
 import type { IApiErrorResponse, IPost } from "@logchimp/types";
 
 import type { InfiniteScrollStateType } from "../../components/ui/InfiniteScroll.vue";
@@ -10,13 +11,12 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
   const posts = ref<IPost[]>([]);
   const state = ref<InfiniteScrollStateType>("IDLE");
 
+  const searchQuery = ref<string | undefined>();
   const endCursor = ref<string | undefined>();
   const hasNextPage = ref<boolean>(false);
   const errorCode = ref<unknown>(undefined);
 
   async function fetchPosts() {
-    if (state.value === "LOADING" || state.value === "COMPLETED") return;
-
     state.value = "LOADING";
     errorCode.value = undefined;
 
@@ -24,7 +24,9 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
 
     try {
       const response = await postsAPI.GetPosts(
-        {},
+        {
+          query: searchQuery.value,
+        },
         {
           after: endCursor.value,
           created: "DESC",
@@ -79,9 +81,27 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
     posts.value.splice(postIdx, 1);
   }
 
+  const debounceFetchPosts = useDebounceFn(async () => {
+    state.value = "IDLE";
+    endCursor.value = undefined;
+    hasNextPage.value = false;
+    errorCode.value = undefined;
+    posts.value = [];
+
+    await fetchPosts();
+  }, 800);
+
+  watch(
+    () => searchQuery.value,
+    async () => {
+      await debounceFetchPosts();
+    },
+  );
+
   return {
     posts,
     state,
+    searchQuery,
     error: errorCode,
 
     fetchPosts,

--- a/packages/theme/src/store/dashboard/posts.ts
+++ b/packages/theme/src/store/dashboard/posts.ts
@@ -61,10 +61,11 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
       }
     } catch (error) {
       const err = error as AxiosError<IApiErrorResponse>;
-      state.value = "ERROR";
 
       // axios request canceled
       if (isCancel(err) || err.code === "ERR_CANCELED") return;
+
+      state.value = "ERROR";
 
       // HTTP API error handling
       switch (err.response?.data?.code) {

--- a/packages/theme/src/store/dashboard/posts.ts
+++ b/packages/theme/src/store/dashboard/posts.ts
@@ -58,11 +58,11 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
         state.value = "COMPLETED";
       }
     } catch (error) {
-      // axios request canceled
-      if (isCancel(error) || (error as any)?.code === "ERR_CANCELED") return;
-
       const err = error as AxiosError<IApiErrorResponse>;
       state.value = "ERROR";
+
+      // axios request canceled
+      if (isCancel(err) || err.code === "ERR_CANCELED") return;
 
       // HTTP API error handling
       switch (err.response?.data?.code) {

--- a/packages/theme/src/store/dashboard/posts.ts
+++ b/packages/theme/src/store/dashboard/posts.ts
@@ -2,10 +2,10 @@ import { ref, watch } from "vue";
 import { defineStore } from "pinia";
 import { useDebounceFn } from "@vueuse/core";
 import type { IApiErrorResponse, IPost } from "@logchimp/types";
+import { type AxiosError, isCancel } from "axios";
 
 import type { InfiniteScrollStateType } from "../../components/ui/InfiniteScroll.vue";
 import { Posts } from "../../modules/posts";
-import type { AxiosError } from "axios";
 
 export const useDashboardPosts = defineStore("dashboardPosts", () => {
   const posts = ref<IPost[]>([]);
@@ -16,7 +16,12 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
   const hasNextPage = ref<boolean>(false);
   const errorCode = ref<unknown>(undefined);
 
+  let abortController: AbortController | null = null;
+
   async function fetchPosts() {
+    abortController?.abort();
+    abortController = new AbortController();
+
     state.value = "LOADING";
     errorCode.value = undefined;
 
@@ -31,7 +36,12 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
           after: endCursor.value,
           created: "DESC",
         },
+        {
+          signal: abortController.signal,
+        },
       );
+
+      if (abortController.signal.aborted) return;
 
       const postsList = response.posts;
 
@@ -48,6 +58,9 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
         state.value = "COMPLETED";
       }
     } catch (error) {
+      // axios request canceled
+      if (isCancel(error) || (error as any)?.code === "ERR_CANCELED") return;
+
       const err = error as AxiosError<IApiErrorResponse>;
       state.value = "ERROR";
 
@@ -82,6 +95,8 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
   }
 
   const debounceFetchPosts = useDebounceFn(async () => {
+    abortController?.abort();
+
     state.value = "IDLE";
     endCursor.value = undefined;
     hasNextPage.value = false;

--- a/packages/theme/src/store/dashboard/posts.ts
+++ b/packages/theme/src/store/dashboard/posts.ts
@@ -95,9 +95,6 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
   }
 
   const debounceFetchPosts = useDebounceFn(async () => {
-    abortController?.abort();
-
-    state.value = "IDLE";
     endCursor.value = undefined;
     hasNextPage.value = false;
     errorCode.value = undefined;
@@ -109,6 +106,9 @@ export const useDashboardPosts = defineStore("dashboardPosts", () => {
   watch(
     () => searchQuery.value,
     async () => {
+      abortController?.abort();
+      state.value = "IDLE";
+
       await debounceFetchPosts();
     },
   );

--- a/packages/types/src/posts/post.ts
+++ b/packages/types/src/posts/post.ts
@@ -36,6 +36,7 @@ export interface IFilterPostRequestQueryParams extends CursorPaginationParams {
 export interface IFilterPostRequestBody {
   boardId?: string[];
   roadmapId?: string;
+  query?: string;
   page?: string;
   limit?: string;
 }


### PR DESCRIPTION
## Summary

Add option to add search posts by title in dashboard

## Type(s) of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] UI
- [ ] Test(s) only
- [ ] Other (Please mention)

## Screenshot(s) / Screen Recording(s) (Optional)

| Preview |
| --- |
| <img width="3216" height="1998" alt="image" src="https://github.com/user-attachments/assets/573fcdf0-dc17-4910-a883-251e3d10731a" /> |

## Testing (Optional)
<!-- Describe how you tested your changes. -->
- [ ] Unit tests
- [ ] Integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added title-based search to the dashboard posts listing.
  * Search results update automatically as users enter a query.
  * Search is case-insensitive and supports partial title matches.
  * Pagination and result counts reflect the active search query.
  * Search terms are trimmed and normalized, including special characters.
  * Previous results are cleared when a new search begins to keep displayed results aligned with the current query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->